### PR TITLE
README.md: Drop "BACKEND" from the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# BACKEND TRAINING
+# DeepSpeed-based Training
 
-This repo contains a standalone deepspeed training implementation.
+This repo contains a standalone DeepSpeed training implementation.


### PR DESCRIPTION
This code is not backend-specific, so drop it from the readme title.
While we're at it, capitalize DeepSpeed as the upstream project does
it.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
