### PR TITLE
More Checkpointing Robustness

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ py-cpuinfo
 # replace custom pytorch images with the 2.3.0
 torch>=2.3.0a0
 transformers==4.41.2
-datasets
+datasets>=2.15.0
 numba
 numpy
 rich
@@ -22,5 +22,5 @@ pydantic>=2.7.0
 # 
 
 # deepspeed needs to be at the bottom or it'll break during installation
-deepspeed==0.14.3
+deepspeed>=0.14.3
 

--- a/src/instructlab/training/utils.py
+++ b/src/instructlab/training/utils.py
@@ -238,16 +238,42 @@ def prepare_peft_model(
 
     return model
 
-def prepare_universal_checkpoint(output_dir):
+def prepare_universal_checkpoint_from_latest(output_dir):
+    """Populate the universal checkpoint in output_dir/step_folder
+    - 1. read output_dir/latest to get step_folder
+    - 2. populate tmp dir in output_dir/step_folder/tmp
+    - 3. populate zero checkpoints in output_dir/step_folder/zero
+    - 4. create output_dir/latest_universal
+
+    Items 1, 2, 3, 4 are idempotent. There is atomicity in the sense that
+    only after 4 is completed, then the output_dir/latest_universal
+    checkpoint is created in which then the universal checkpoint 
+    can be loaded.
+
+    Be aware that this creates an extra dir `zero/` in the checkpoint dir,
+    which doubles the DS checkpoint storage requirement.
+    - DS checkpoints store 3X model parameters in 32bit.
+    - e.g., will be 6X a model paramter-only checkpoint in 16bit.
+
+    Note that this requires a latest version of deepspeed. It kind of works if
+    the model is not saving universal checkpoint info, but only in the
+    the case where advanced features like tensor parallel (TP) and
+    pipeline parallel (PP) are turned off.
+    """
+
     log_rank_0(f"\033[93mPreparing universal checkpoint in {output_dir}\033[0m", to_print=True)
+    from transformers.utils.import_utils import _is_package_available
+    _, ds_version = _is_package_available('deepspeed', return_version=True)
+    if ds_version < '0.14.3':
+        raise ValueError(
+            'universal checkpoint only supported on deepspeed >= 0.14.3'
+        )
+
     start = time.time()
     if torch.distributed.get_rank() == 0:
-        # TODO: check the DS version, require quite latest version
-        # TODO: if alreay craeted then we can skip it
 
         from deepspeed.checkpoint.ds_to_universal import (
             _check_for_required_state,
-            _create_checkpoint_paths,
             _extract_zero_shard_files,
             _save_optimizer_state,
             _merge_tp_slice_files,
@@ -255,38 +281,42 @@ def prepare_universal_checkpoint(output_dir):
             PARAM_SHAPES
         )
         from deepspeed.checkpoint import DeepSpeedCheckpoint
-        import os, shutil
+        import os, shutil, warnings
 
+        # read the latest file to get the step folder
         latest_file = output_dir / "latest"
         with open (latest_file) as f:
             step_folder = f.read()
 
+        # will process the checkpoint in the latest step folder
         input_folder = os.path.join(output_dir, step_folder)
-        # output_folder = input_folder # just put it in same place
 
-        # cvreate args
-        class WorkerArgs:
+        # create args for the scripts below
+        class UniversalCheckpointArgs:
             num_extract_workers: int = 1
             num_merge_workers: int = 1
             output_folder: str = input_folder # just put in same place
-            strict: bool = True
-        args = WorkerArgs()
+            strict: bool = True # strict checkpoint
+        args = UniversalCheckpointArgs()
 
-        # this is not very reliable, it is copied from main
+        # get the checkpoint
         ds_checkpoint = DeepSpeedCheckpoint(input_folder)
 
-        # this is a hack, not super confident
+        # hack, force this to null if we did not properly save 
+        # any universal checkpoint information
+        # - this will not support any pipeline replication and other 
+        #   replication such as TP, row parallelism, vocab, sub_params
         if UNIVERSAL_CHECKPOINT_INFO not in  ds_checkpoint.global_state:
+            warnings.warn(
+                "Universal checkpoint information not found, setting it to "
+                "an empty dictionary."
+            )
             ds_checkpoint.global_state[UNIVERSAL_CHECKPOINT_INFO] = {}
-
+            assert ds_checkpoint.tp_degree == 1, \
+                    "if universal checkpointing info is missing, TP must be absent"
+            assert ds_checkpoint.pp_degree == 1, \
+                    "if universal checkpointing info is missing, PP must be absent"
         _check_for_required_state(ds_checkpoint)
-
-        # iteration = ds_checkpoint.get_iteration()
-        #_create_latest_file(args.output_folder, iteration)
-        # checkpoint_paths = _create_checkpoint_paths(
-        #     output_folder, iteration, ds_checkpoint.tp_degree,
-        #     ds_checkpoint.pp_degree
-        # )
 
         slice_shapes = []
         for mp_rank_file in ds_checkpoint.mp_rank_files:
@@ -300,20 +330,19 @@ def prepare_universal_checkpoint(output_dir):
         log_rank_0(f"\033[93m1. Extracting ZeRO fragments into {temp_dir}\033[0m", to_print=True)
         _extract_zero_shard_files(args, ds_checkpoint, temp_dir)
 
-        print('*** 2. Merging slices .....')
         zero_output_folder = os.path.join(args.output_folder, "zero")
 
         log_rank_0(f"\033[93m2. Merging slices into {zero_output_folder}\033[0m", to_print=True)
         _merge_tp_slice_files(args, ds_checkpoint, slice_shapes, temp_dir)
 
-        print('*** 3. Saving common optimizer states')
         log_rank_0(f"\033[93m3. Saving common optimizer states into {zero_output_folder}\033[0m", to_print=True)
         _save_optimizer_state(args, ds_checkpoint)
 
-        log_rank_0(f"\033[93m3. Removing temp directory {temp_dir}\033[0m", to_print=True)
+        log_rank_0(f"\033[93m4. Removing temp directory {temp_dir}\033[0m", to_print=True)
         shutil.rmtree(temp_dir, ignore_errors=True)
 
         latest_file = os.path.join(output_dir, 'latest_universal')
+        log_rank_0(f"\033[93m5. Creating {latest_file}\033[0m", to_print=True)
         with open(latest_file, "w") as f:
             f.write(step_folder)
 


### PR DESCRIPTION
- add universal checkpointing

To verify
1. train until a `ds_native` checkpoint is saved, stop the `torchrun` process.
2. restart `torchrun` with a different `num_proc` while using the *exact same train command*, 
3. observe printouts for creating the universal checkpoint in the `latest` directory. Training will resume with the different `num_proc`

Results on Dolomite full FT
- wrong learning rate was inadvertently used here, but it does prove that the method works.

![image](https://github.com/instructlab/training/assets/8325951/4c783ea1-3871-49a8-8b9d-afcd82b7d174)

Results on Dolomite QLoRA

![image](https://github.com/instructlab/training/assets/8325951/26a0006f-d3da-4f8e-8a5a-f7d4edc0122e)
