### PR TITLE
Make md-lint ignore the tox directory

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -13,3 +13,4 @@ ignores:
   - ".github/**"
   - "venv/**"
   - ".venv/**"
+  - ".tox/**"


### PR DESCRIPTION
Ensure `make md-lint` works even after running `tox`. We don't want
the linter looking at anything inside the tox virtualenvs.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
