### PR TITLE
convert enum to str when referencing

### DIFF
--- a/src/instructlab/training/config.py
+++ b/src/instructlab/training/config.py
@@ -74,7 +74,11 @@ class LoraOptions(BaseModel):
     target_modules: list[str] = Field(
         default_factory=lambda: ["q_proj", "k_proj", "v_proj", "o_proj"]
     )
+    
     quantize_data_type: QuantizeDataType = QuantizeDataType.NONE
+
+    class Config:  
+        use_enum_values = True
 
 
 class DeepSpeedOptions(BaseModel):


### PR DESCRIPTION
click does not support an enum type for click.choice. This means that in the CLI we need to somehow get from str -> enum to pass to the library.

Adding this use_enum_values, allows a user to specify things like `nf4` and `None` as strs in their config.yaml and they are seen as valid by the library.