### PR TITLE
Add LR scheduler and Fix Granite Checkpoint Loading

### DIFF
--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -231,7 +231,7 @@ def setup_model(args, tokenizer, train_loader, grad_accum):
         )
 
     lr_scheduler = get_scheduler(
-        name="cosine",
+        name=args.lr_scheduler,
         optimizer=optimizer,
         num_warmup_steps=args.num_warmup_steps,
         num_training_steps=args.num_epochs * len(train_loader),
@@ -651,6 +651,20 @@ if __name__ == "__main__":
     # parser.add_argument("--samples_per_gpu", type=int, default=8)
     parser.add_argument("--effective_batch_size", type=int, default=3840)
     parser.add_argument("--learning_rate", type=float, default=1e-4)
+    parser.add_argument(
+        "--lr_scheduler",
+        type=str,
+        default="cosine",
+        help="The scheduler type to use.",
+        choices=[
+            "linear",
+            "cosine",
+            "cosine_with_restarts",
+            "polynomial",
+            "constant",
+            "constant_with_warmup",
+        ],
+    )
     parser.add_argument("--num_warmup_steps", type=int, default=1000)
     # parser.add_argument("--gradient_accumulation_steps", type=int, default=1)
     parser.add_argument("--save_samples", type=int)

--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -447,6 +447,13 @@ def train(args, model, tokenizer, train_loader, grad_accum, metric_logger):
             if local_rank == 0:
                 inner_pb.update(1)
             torch.cuda.empty_cache()
+    if args.save_last:
+        save_hf_format_ds(
+            args,
+            model,
+            tokenizer,
+            global_step * args.samples_per_gpu * world_size,
+        )
 
 
 def main(args):
@@ -673,6 +680,9 @@ if __name__ == "__main__":
         type=int,
         help="for saving in ds native format",
         default=None,
+    )
+    parser.add_argument(
+        "--save_last", action="store_true", help="save after finishing training"
     )
     parser.add_argument("--log_level", type=str, default="INFO")
     parser.add_argument("--seed", type=int, default=42)

--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -95,7 +95,10 @@ def setup_model(args, tokenizer, train_loader, grad_accum):
         )
 
     if args.is_granite:
-        with ensure_loadable_granite_checkpoint(args.model_name_or_path) as path:
+        with ensure_loadable_granite_checkpoint(
+            args.model_name_or_path, 
+            args.output_dir
+        ) as path:
             model = GPTDolomiteForCausalLM.from_pretrained(
                 path,
                 attn_implementation="flash_attention_2",

--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -96,8 +96,7 @@ def setup_model(args, tokenizer, train_loader, grad_accum):
 
     if args.is_granite:
         with ensure_loadable_granite_checkpoint(
-            args.model_name_or_path, 
-            args.output_dir
+            args.model_name_or_path, args.output_dir
         ) as path:
             model = GPTDolomiteForCausalLM.from_pretrained(
                 path,

--- a/src/instructlab/training/utils.py
+++ b/src/instructlab/training/utils.py
@@ -2,7 +2,7 @@
 from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
-from tempfile import TemporaryDirectory, mktemp
+from tempfile import TemporaryDirectory
 from typing import Any, List, Optional
 import importlib
 import inspect
@@ -486,7 +486,6 @@ def ensure_loadable_granite_checkpoint(
     model_name_or_path: str,
     tmpdir: str,
 ):
-
     local_rank = int(os.environ["LOCAL_RANK"])
     group_rank = int(os.environ["GROUP_RANK"])
 
@@ -505,11 +504,8 @@ def ensure_loadable_granite_checkpoint(
         # so now we use a provided tmpdir
         # Assumption: tmpdir should be accessible by all ranks, even those
         # in different nodes
-        tmpdir = Path(tmpdir) / f'tmp.{group_rank}'
-        if (
-            os.path.exists(tmpdir) and
-            (not dist.is_initialized() or local_rank == 0)
-        ):
+        tmpdir = Path(tmpdir) / f"tmp.{group_rank}"
+        if os.path.exists(tmpdir) and (not dist.is_initialized() or local_rank == 0):
             # need to delete if it exists because import doesnt like it to
             shutil.rmtree(tmpdir, ignore_errors=True)
 
@@ -517,7 +513,7 @@ def ensure_loadable_granite_checkpoint(
             import_from_huggingface(model_name_or_path, tmpdir)
 
         if dist.is_initialized():
-            # the first barrier is to wait for local rank 0 to finish converting the model 
+            # the first barrier is to wait for local rank 0 to finish converting the model
             # and place into tmpdir
             dist.barrier()
 

--- a/src/instructlab/training/utils.py
+++ b/src/instructlab/training/utils.py
@@ -487,8 +487,6 @@ def ensure_loadable_granite_checkpoint(
     tmpdir: str,
 ):
 
-    # this has to be done per node, so we use local rank
-    local_rank = int(os.environ["LOCAL_RANK"])
     try:
         GPTDolomiteConfig.from_pretrained(model_name_or_path)
         yield model_name_or_path
@@ -501,18 +499,31 @@ def ensure_loadable_granite_checkpoint(
         # for now just assume its a llama
         # make a temp directory name, but do not create it
         # previously we used mktemp, but it caused problems in multi node settings
-        # so now we use a provided
+        # so now we use a provided tmpdir
+        # Assumption: tmpdir should be accessible by all ranks, even those
+        # in different nodes
         tmpdir = Path(tmpdir) / 'tmp'
         if os.path.exists(tmpdir):
             # need to delete if it exists because import doesnt like it to
             shutil.rmtree(tmpdir, ignore_errors=True)
 
-        if not dist.is_initialized() or local_rank == 0:
+        if not dist.is_initialized() or dist.get_rank() == 0:
             import_from_huggingface(model_name_or_path, tmpdir)
+
         if dist.is_initialized():
+            # the first barrier is to wait for rank 0 to finish converting the model 
+            # and place into tmpdir
             dist.barrier()
+
+        # return tmpdir out for loading
         yield tmpdir
-        if not dist.is_initialized() or local_rank == 0:
+
+        if dist.is_initialized():
+            # the second barrier is to wait for all the models to finish loading
+            dist.barrier()
+
+        if not dist.is_initialized() or dist.get_rank() == 0:
+            # at this point, we can be confident that the tmpdir is no longer needed
             shutil.rmtree(tmpdir, ignore_errors=True)
 
 


### PR DESCRIPTION
This PR adds the LR scheduler configuration and also fixes the granite loading issue for multinode settings.
- this PR subsumes the changes in @aldo-pareja 's `lr_scheduler` branch, so a seperate merge of that would not be necessary
- the strategy now for converting the granite checkpoint, is that each node will elect one local rank to do the convert.
- the conversion will be one on the `args.output_dir`. There is no assumption it is the same for all nodes or not.  But assuming they might be the same, the `tmpdir` is shared by a `.{group_rank}` postfix. See [group rank](https://pytorch.org/docs/stable/elastic/run.html#environment-variables)
- tested on multi node