### PR TITLE
Add Control To Turn Off Multipack

### DIFF
--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -346,9 +346,9 @@ def train(args, model, tokenizer, train_loader, grad_accum, metric_logger):
 
     for epoch in range(args.num_epochs):
         torch.distributed.barrier()
-        if args.sampler in ('multipack'):
+        if args.sampler in ("multipack"):
             train_loader.batch_sampler.set_epoch(epoch)
-        elif args.sampler in ('distributed'):
+        elif args.sampler in ("distributed"):
             train_loader.sampler.set_epoch(epoch)
         else:
             raise NotADirectoryError
@@ -686,10 +686,7 @@ if __name__ == "__main__":
         type=str,
         default="multipack",
         help="The batch sampler type to use.",
-        choices=[
-            "multipack",
-            "distributed"
-        ],
+        choices=["multipack", "distributed"],
     )
     parser.add_argument("--num_warmup_steps", type=int, default=1000)
     # parser.add_argument("--gradient_accumulation_steps", type=int, default=1)

--- a/src/instructlab/training/token_dataset.py
+++ b/src/instructlab/training/token_dataset.py
@@ -85,6 +85,7 @@ def setup_dataloader(
     is_granite=False,
     max_batch_len=60000,
     packing_max_batch_len=60000,
+    batch_sampler='multipack',
     seed=47,
 ) -> DataLoader:
     collate_fn = make_collate_fn(
@@ -94,14 +95,18 @@ def setup_dataloader(
     world_size = int(os.environ["WORLD_SIZE"])
 
     lengths = dataset.get_lengths()
-    sampler = MultipackDistributedBatchSampler(
-        batch_max_length=packing_max_batch_len,
-        lengths=lengths,
-        num_replicas=world_size,
-        rank=rank,
-        seed=seed,
-        padding=not is_granite,
-    )
+    if batch_sampler == 'multipack':
+        sampler = MultipackDistributedBatchSampler(
+            batch_max_length=packing_max_batch_len,
+            lengths=lengths,
+            num_replicas=world_size,
+            rank=rank,
+            seed=seed,
+            padding=not is_granite,
+        )
+    elif batch_sampler == 'default':
+        sampler = None
+
     dataloader = DataLoader(
         dataset,
         batch_sampler=sampler,

--- a/src/instructlab/training/token_dataset.py
+++ b/src/instructlab/training/token_dataset.py
@@ -85,7 +85,8 @@ def setup_dataloader(
     is_granite=False,
     max_batch_len=60000,
     packing_max_batch_len=60000,
-    batch_sampler='multipack',
+    samples_per_gpu=None,
+    sampler='multipack',
     seed=47,
 ) -> DataLoader:
     collate_fn = make_collate_fn(
@@ -95,7 +96,7 @@ def setup_dataloader(
     world_size = int(os.environ["WORLD_SIZE"])
 
     lengths = dataset.get_lengths()
-    if batch_sampler == 'multipack':
+    if sampler == 'multipack':
         sampler = MultipackDistributedBatchSampler(
             batch_max_length=packing_max_batch_len,
             lengths=lengths,
@@ -104,12 +105,23 @@ def setup_dataloader(
             seed=seed,
             padding=not is_granite,
         )
-    elif batch_sampler == 'default':
-        sampler = None
+        sampler = {'batch_sampler': sampler}
+    elif sampler == 'distributed':
+        from torch.utils.data import DistributedSampler
+        sampler = (
+            DistributedSampler(dataset) if 
+            torch.distributed.is_initialized() else None
+        )
+        sampler = {
+            'sampler': sampler,
+            'batch_size': samples_per_gpu,
+        }
+    else:
+        raise NotImplementedError
 
     dataloader = DataLoader(
         dataset,
-        batch_sampler=sampler,
+        **sampler,
         num_workers=num_workers,
         collate_fn=collate_fn,
     )

--- a/src/instructlab/training/token_dataset.py
+++ b/src/instructlab/training/token_dataset.py
@@ -86,7 +86,7 @@ def setup_dataloader(
     max_batch_len=60000,
     packing_max_batch_len=60000,
     samples_per_gpu=None,
-    sampler='multipack',
+    sampler="multipack",
     seed=47,
 ) -> DataLoader:
     collate_fn = make_collate_fn(
@@ -96,7 +96,7 @@ def setup_dataloader(
     world_size = int(os.environ["WORLD_SIZE"])
 
     lengths = dataset.get_lengths()
-    if sampler == 'multipack':
+    if sampler == "multipack":
         sampler = MultipackDistributedBatchSampler(
             batch_max_length=packing_max_batch_len,
             lengths=lengths,
@@ -105,16 +105,17 @@ def setup_dataloader(
             seed=seed,
             padding=not is_granite,
         )
-        sampler = {'batch_sampler': sampler}
-    elif sampler == 'distributed':
+        sampler = {"batch_sampler": sampler}
+    elif sampler == "distributed":
+        # Third Party
         from torch.utils.data import DistributedSampler
+
         sampler = (
-            DistributedSampler(dataset) if 
-            torch.distributed.is_initialized() else None
+            DistributedSampler(dataset) if torch.distributed.is_initialized() else None
         )
         sampler = {
-            'sampler': sampler,
-            'batch_size': samples_per_gpu,
+            "sampler": sampler,
+            "batch_size": samples_per_gpu,
         }
     else:
         raise NotImplementedError


### PR DESCRIPTION
Multipack can sometimes cause a GPU to be assigned 0 samples if the effective batch size is very small. 
- this provides an additional control `sampler`, and can be set to `"distributed"` or `"multipack"` (default)
- The `distributed` version is just a random sampler. However, we will still call `find_packing_max_batch_len_and_grad_accum` to get the `grad_accum` and `samples_per_gpu` 