### PR TITLE
fix: changes the check to check against both the enum option and enum value. Currently when we compare the type that gets passed in from the training args by only doing a check against the enum

### DIFF
--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,1 +1,2 @@
 flash-attn>=2.4.0
+bitsandbytes

--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -640,7 +640,12 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
             + train_args.lora.target_modules
         )
         # hard-code 4-bit quantization for now, change this when we add more
-        if train_args.lora.quantize_data_type == config.QuantizeDataType.NF4:
+        quant_dtype = train_args.lora.quantize_data_type
+        quantization_is_enabled = quant_dtype in (
+            config.QuantizeDataType.NF4,
+            config.QuantizeDataType.NF4.value,
+        )
+        if quantization_is_enabled:
             command.append("--lora_quant_bits=4")
 
     # deepspeed opts


### PR DESCRIPTION
We update the check for qunatization to now check against both the enum option and enum option value.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
