### PR TITLE
fix: cap flash-attention version

### DIFF
--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,2 +1,2 @@
-flash-attn>=2.4.0
+flash-attn>=2.4.0,<2.6.3
 bitsandbytes>=0.43.1


### PR DESCRIPTION
A bug exists in flash-attention version 2.6.3, where running training would yield
an error about an unknown symbol whenever flash-attention was imported.
Until this error is resolved, we should limit our versions of
flash attention to be 2.6.2 and lower. Versions that were tested manually
and verified to work properly have been: 2.6.2, 2.6.1, 2.5.0, 2.4.1, and 2.3.0.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
