### PR TITLE
Adds a flag to save checkpoints at the end of an epoch

### DIFF
--- a/src/instructlab/training/config.py
+++ b/src/instructlab/training/config.py
@@ -139,6 +139,7 @@ class TrainingArgs(BaseModel):
     warmup_steps: int
     is_padding_free: bool
     random_seed: int = 42
+    checkpoint_at_epoch: bool = False
 
     mock_data: Optional[bool] = False
     mock_data_len: int = 0


### PR DESCRIPTION
Currently, we save checkpoints:

1. Whenever we pass enough samples, and
2. sometimes at the end of training.

This adds saving per-epoch, so one could set save_samples really high and ONLY
save at the boundary of epochs.
