### PR TITLE
Accept tuples for lora.target_modules

### DIFF
--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -638,8 +638,8 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
                 f"--lora_dropout={train_args.lora.dropout}",
                 "--lora_target_modules",
             ]
-            + train_args.lora.target_modules
         )
+        command.extend(train_args.lora.target_modules)
         # hard-code 4-bit quantization for now, change this when we add more
         quant_dtype = train_args.lora.quantize_data_type
         quantization_is_enabled = quant_dtype in (


### PR DESCRIPTION
Pydantic field is defined as `list`, but in pydantic world, it means more than just lists. E.g. it allows tuples.

https://docs.pydantic.dev/2.0/usage/types/list_types/

This patch fixes the TypeError raised from the attempt to concatenate a list with a tuple.

Related: https://github.com/instructlab/instructlab/issues/2021