### PR TITLE
feat: automatically select LoRA modules when none are provided

### DIFF
--- a/src/instructlab/training/config.py
+++ b/src/instructlab/training/config.py
@@ -6,7 +6,7 @@ Collection of config objects used in the InstructLab training library.
 
 # Standard
 from enum import Enum
-from typing import Optional
+from typing import List, Optional
 import os
 
 # Third Party
@@ -89,9 +89,13 @@ class LoraOptions(BaseModel):
     rank: int = 4
     alpha: int = 32
     dropout: float = 0.1
-    target_modules: list[str] = Field(
-        default_factory=lambda: ["q_proj", "k_proj", "v_proj", "o_proj"]
-    )
+
+    """
+    Selects the linear layers that we target for LoRA training.
+    When set to `None`, it selects all projection layers in the model (matching `_proj`).
+    `None` by default.
+    """
+    target_modules: Optional[List[str]] = None
 
     quantize_data_type: QuantizeDataType = QuantizeDataType.NONE
 

--- a/src/instructlab/training/utils.py
+++ b/src/instructlab/training/utils.py
@@ -35,6 +35,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     apply_activation_checkpointing,
     checkpoint_wrapper,
 )
+from transformers import PreTrainedModel
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -897,3 +898,15 @@ def load_latest_full_state(args, accelerator) -> None:
     # previous epoch is basis for current epoch.
     args.__dict__["current_epoch"] = training_metadata["current_epoch"] + 1
     args.__dict__["samples_seen"] = training_metadata["samples_seen"]
+
+
+def get_projection_layer_names(model: PreTrainedModel) -> List[str]:
+    """
+    Given a pretrained model, returns all of the projection layers (matching '_proj')
+    """
+    proj_layers = set(
+        name.split(".")[-1]
+        for name, _ in model.named_modules()
+        if name.endswith("_proj")
+    )
+    return list(proj_layers)


### PR DESCRIPTION
In the current version of the training library, we have the default value of target_modules set to
a list oflayer names which are implementation-specific and may not reflect what a given model actually
uses for the layer names. Furthermore, the default is also a subset of all projection layers in most models,
and the recommendation is generally to use all of these layers when injecting low rank adapters.

This commit resolves that issue by introducing logic to automatically resolve the target modules
and default to using all of them when they are not provided. This commit also adds validation logic
which indicates when some of the provided modules do not exist in the model. To go a step further,
the training library will also now error out when none of the provided target modules exist in the model,
supplying the user with additional context on which modules exist and how they could resolve the error

Signed-off-by: Oleg S <ec2-user@ip-10-0-24-47.us-east-2.compute.internal>
