### PR TITLE
Provide safeguards during training

### DIFF
--- a/src/instructlab/training/data_process.py
+++ b/src/instructlab/training/data_process.py
@@ -204,9 +204,18 @@ def main(args: DataProcessArgs):
         {"additional_special_tokens": ["<|pretrain|>", "<|/pretrain|>"]}
     )
 
-    data = load_dataset("json", data_files=args.data_path, split="train")
+    try:
+        data = load_dataset("json", data_files=args.data_path, split="train")
+    except:
+        # pylint: disable=raise-missing-from,broad-exception-raised
+        raise Exception(
+            "Malformed or missing data, please ensure that your dataset is not empty and correctly formatted"
+        )
+
     if data.num_rows == 0:
-        raise ValueError("The provided dataset is empty, please make sure that you were able to generate a dataset and try again.")
+        raise ValueError(
+            "The provided dataset is empty, please make sure that your dataset contains samples and try again."
+        )
 
     print(f"\033[92mtokenizing the dataset with {args.model_path} tokenizer...\033[0m")
     data_with_input_ids = data.map(
@@ -233,8 +242,9 @@ def main(args: DataProcessArgs):
     )
     print(f"\033[36m({((num_dropped_samples / len(lens)) * 100):.2f}% of total)\033[0m")
     if num_dropped_samples == len(data):
-        raise RuntimeError(f"Dataset does not contain any samples containing less than {args.max_seq_len=} tokens.\nPlease consider increasing your `max_seq_len` value, or adding more samples.")
-
+        raise RuntimeError(
+            f"Dataset does not contain any samples containing less than {args.max_seq_len=} tokens.\nPlease consider increasing your `max_seq_len` value, or adding more samples."
+        )
 
     lowest_10_percent = np.quantile(lens, (0 + np.arange(11)) / 100.0)
     for i, q in enumerate(lowest_10_percent):

--- a/src/instructlab/training/data_process.py
+++ b/src/instructlab/training/data_process.py
@@ -205,6 +205,8 @@ def main(args: DataProcessArgs):
     )
 
     data = load_dataset("json", data_files=args.data_path, split="train")
+    if data.num_rows == 0:
+        raise ValueError("The provided dataset is empty, please make sure that you were able to generate a dataset and try again.")
 
     print(f"\033[92mtokenizing the dataset with {args.model_path} tokenizer...\033[0m")
     data_with_input_ids = data.map(
@@ -230,6 +232,9 @@ def main(args: DataProcessArgs):
         f"\033[36mat {args.max_seq_len} max sequence length, the number of samples to be dropped is {num_dropped_samples}\033[0m"
     )
     print(f"\033[36m({((num_dropped_samples / len(lens)) * 100):.2f}% of total)\033[0m")
+    if num_dropped_samples == len(data):
+        raise RuntimeError(f"Dataset does not contain any samples containing less than {args.max_seq_len=} tokens.\nPlease consider increasing your `max_seq_len` value, or adding more samples.")
+
 
     lowest_10_percent = np.quantile(lens, (0 + np.arange(11)) / 100.0)
     for i, q in enumerate(lowest_10_percent):

--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -585,6 +585,9 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
     """
     Wrapper around the main training job that calls torchrun.
     """
+    # early validation logic here
+    if train_args.max_batch_len < train_args.max_seq_len:
+        raise ValueError(f"the `max_batch_len` cannot be less than `max_seq_len`: {train_args.max_batch_len=} < {train_args.max_seq_len=}")
 
     # process the training data
     if not os.path.exists(train_args.data_output_dir):


### PR DESCRIPTION

This PR adds safeguards to prevent the following issues:

- preventing the multipack sampler from being used when it cannot adequately process all samples
- prevent empty datasets from being provided or created
- prevent `max_batch_len` from being smaller than `max_seq_len`

