### PR TITLE
fix: improve linting and automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,6 @@ tests: check-tox ## Run type checks.
 
 
 .PHONY: fix
-fix: check-tox ## Fix everything that's fixable by the automaed tooling.
+fix: check-tox ## Fix everything that's fixable by the automated tooling.
 	tox -e fix
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,26 +6,24 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instructlab-training"
-authors = [
-    { name="InstructLab", email="dev@instructlab.ai" },
-]
+authors = [{ name = "InstructLab", email = "dev@instructlab.ai" }]
 description = "Training Library"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 classifiers = [
-    "Development Status :: 3 - Alpha",
-    "Environment :: Console",
-    "License :: OSI Approved :: Apache Software License",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: MacOS :: MacOS X",
-    "Operating System :: POSIX :: Linux",
-    "Topic :: Scientific/Engineering :: Artificial Intelligence",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: Implementation :: CPython",
+  "Development Status :: 3 - Alpha",
+  "Environment :: Console",
+  "License :: OSI Approved :: Apache Software License",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: MacOS :: MacOS X",
+  "Operating System :: POSIX :: Linux",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: Implementation :: CPython",
 ]
 dynamic = ["dependencies", "optional-dependencies", "version"]
 
@@ -42,10 +40,10 @@ version_file = "src/instructlab/training/_version.py"
 local_scheme = "no-local-version"
 
 [tool.setuptools]
-package-dir = {"" = "src"}
+package-dir = { "" = "src" }
 
 [tool.setuptools.dynamic]
-dependencies = {file = ["requirements.txt"]}
+dependencies = { file = ["requirements.txt"] }
 optional-dependencies.cuda = { file = ["requirements-cuda.txt"] }
 
 [tool.setuptools.packages.find]
@@ -64,20 +62,20 @@ unfixable = []
 
 # Fixers will be enabled gradually.
 select = [
-    # "B",  # flake8-bugbear
-    # "E",  # pycodestyle
-    # "F",  # Pyflakes
-    "Q",  # flake8-quotes
-    # Ruff does not support isort's import_headings feature, yet.
-    # "I",  # isort
-    # "UP",  # pyupgrade
-    # "SIM",  # flake8-simplify
-    "TID",  # flake8-tidy-imports
+  # "B",  # flake8-bugbear
+  # "E",  # pycodestyle
+  # "F",  # Pyflakes
+  "Q", # flake8-quotes
+  # Ruff does not support isort's import_headings feature, yet.
+  # "I",  # isort
+  # "UP",  # pyupgrade
+  # "SIM",  # flake8-simplify
+  "TID", # flake8-tidy-imports
 ]
 ignore = [
-    # some embedded strings are longer than 88 characters
-    "E501",  # line too long
-    "TID252",  # Prefer absolute imports over relative imports from parent modules
+  # some embedded strings are longer than 88 characters
+  "E501",   # line too long
+  "TID252", # Prefer absolute imports over relative imports from parent modules
 ]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
@@ -95,10 +93,15 @@ from-first = true
 known-local-folder = ["tuning"]
 
 [tool.mypy]
-disable_error_code = ["import-not-found", "import-untyped", "var-annotated", "attr-defined"]
+disable_error_code = [
+  "import-not-found",
+  "import-untyped",
+  "var-annotated",
+  "attr-defined",
+]
 exclude = [
-    "^src/instructlab/training/generate_data\\.py$",
-    "^src/instructlab/training/utils\\.py$",
+  "^src/instructlab/training/generate_data\\.py$",
+  "^src/instructlab/training/utils\\.py$",
 ]
 # honor excludes by not following there through imports
 follow_imports = "silent"

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,24 @@
 envlist = ruff, lint, mypy, spellcheck
 minversion = 4.4
 
+[testenv]
+description = run tests
+package = wheel
+wheel_build_env = pkg
+deps =
+    pytest
+    pytest-asyncio
+    pytest-cov
+    pytest-html
+
+[testenv:py3]
+basepython = python3.11
+
 # format, check, and linting targets don't build and install the project to
 # speed up testing.
 [testenv:lint]
 description = lint with pylint
+basepython = {[testenv:py3]basepython}
 skip_install = true
 skipsdist = true
 deps = -r requirements-dev.txt
@@ -18,6 +32,7 @@ commands =
 
 [testenv:fastlint]
 description = fast lint with pylint (without 3rd party modules)
+basepython = {[testenv:py3]basepython}
 skip_install = true
 skipsdist = true
 deps =
@@ -28,6 +43,7 @@ commands =
 
 [testenv:ruff]
 description = reformat and fix code with Ruff (and isort)
+basepython = {[testenv:py3]basepython}
 skip_install = True
 skipsdist = true
 # keep in sync with .pre-commit-config.yaml
@@ -39,8 +55,21 @@ commands =
     ./scripts/ruff.sh {posargs:fix}
 allowlist_externals = ./scripts/ruff.sh
 
+[testenv:tomllint]
+description = lint and format pyproject.toml
+skip_install = true
+skipsdist = true
+deps =
+commands =
+    make toml-lint
+    make toml-fmt
+    sh -c 'git diff --exit-code || (echo "pyproject.toml formatting is incorrect. Please run \"make toml-fmt\" and commit the changes." && exit 1)'
+allowlist_externals = make, sh
+
+
 [testenv:spellcheck]
 description = spell check (needs 'aspell' command)
+basepython = {[testenv:py3]basepython}
 skip_install = true
 skipsdist = true
 deps =
@@ -52,6 +81,7 @@ allowlist_externals = sh
 
 [testenv:mypy]
 description = Python type checking with mypy
+basepython = {[testenv:py3]basepython}
 skip_install = true
 skipsdist = true
 deps =
@@ -60,4 +90,15 @@ deps =
   types-PyYAML
   pytest
 commands =
-  mypy src
+  mypy {posargs:src}
+
+[testenv:fix]
+description = reformat and fix violations with ruff
+basepython = {[testenv:py3]basepython}
+skip_install = true
+skipsdist = true
+deps = {[testenv:ruff]deps}
+commands =
+    ruff check {posargs:--fix}
+    ruff format .
+    isort .


### PR DESCRIPTION
In the current version of the training repo, we have a few commands that help us lint
and check to see if there are any issues with types or incorrect imports. However;
there is no easy fix available when these issues are detected.

This commit introduces a few new functionalities:

1. Makefile receives 5 new commands:
 - toml-lint, which lints the pyproject.toml file
 - toml-fmt, which automatically formats the pyproject.toml file
 - check-engine, which checks that the specified container engine ($CENGINE) is installed
 - tests, which runs tests against the source repo
 - fix, which fixes all fixable issues

2. The tox.ini file receives a few additions:
  a. The testenv environment is defined with some preset values. Other targets are able to pull from this
  b. tox -e fix is added - automatically fixes all fixable problems
  c. tox -e tomllint is added - fixes all issues in the pyproject.toml file
  d. a [py] environment is added to specify the base python version

Aside from this, the resulting pyproject.toml file is added after formatting  is applied.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>