### PR TITLE
ci: update runner labels to uniquely identify instance sizes

### DIFF
--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -49,7 +49,7 @@ jobs:
           iam-role-name: instructlab-ci-runner
           aws-resource-tags: >
             [
-              {"Key": "Name", "Value": "instructlab-ci-github-runner"},
+              {"Key": "Name", "Value": "instructlab-ci-github-small-runner"},
               {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
             ]
   e2e:


### PR DESCRIPTION
To be consistent with new CLI change in https://github.com/instructlab/instructlab/pull/2126