### PR TITLE
add support for CPU and MPS

### DIFF
--- a/src/instructlab/training/__init__.py
+++ b/src/instructlab/training/__init__.py
@@ -22,9 +22,11 @@ from .config import (
 
 
 # defer import of main_ds
-def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
+def run_training(
+    torch_args: TorchrunArgs, train_args: TrainingArgs, device: str = "cuda"
+) -> None:
     """Wrapper around the main training job that calls torchrun."""
     # Local
     from .main_ds import run_training
 
-    return run_training(torch_args=torch_args, train_args=train_args)
+    return run_training(torch_args=torch_args, train_args=train_args, device=device)

--- a/src/instructlab/training/multipack_sampler.py
+++ b/src/instructlab/training/multipack_sampler.py
@@ -30,7 +30,6 @@ from typing import List, Optional
 from torch.utils.data import Sampler
 import numba
 import numpy as np
-import torch
 import torch.distributed as dist
 
 
@@ -67,11 +66,16 @@ def find_max_pack_len_with_padding(
 
         The function creates a sampler using the MultipackDistributedBatchSampler class, generates batches using the sampler, and then returns the ratio of the dataset size to the number of batches.
         """
+        num_replicas = 1
+        rank = 0
+        if dist.is_initialized():
+            num_replicas = dist.get_world_size()
+            rank = dist.get_rank()
         sampler = MultipackDistributedBatchSampler(
             batch_max_length=num_tokens_per_gpu,
             lengths=dataset.get_lengths(),
-            num_replicas=torch.distributed.get_world_size(),
-            rank=torch.distributed.get_rank(),
+            num_replicas=num_replicas,
+            rank=rank,
             seed=seed,
             padding=True,
         )

--- a/src/instructlab/training/token_dataset.py
+++ b/src/instructlab/training/token_dataset.py
@@ -85,6 +85,7 @@ def setup_dataset(
 
 def setup_dataloader(
     dataset: Dataset,
+    multiprocessing: str,
     pad_token_id: int,
     num_workers: int = 8,
     is_granite=False,
@@ -128,6 +129,7 @@ def setup_dataloader(
     dataloader = DataLoader(
         dataset,
         **sampler,
+        multiprocessing_context=multiprocessing,
         num_workers=num_workers,
         collate_fn=collate_fn,
     )


### PR DESCRIPTION
do not use distributed when not available, instead use CPU or MPS.

This entails a few changes:

* --device is now a valid flag to the library since `ilab` can pass CPU, MPS, or default to cuda when using CPU or MPS, 
* do not initialize DS, instead put the model on the device and initialize `Adafactor` optimizer which is more efficient and than Adam based one
*  inside of `train` add logic for handling if torch.cuda.is_available and torch.distributed.is_initialized() we dont use distributed torch on consumer systems 
* the train loop needs some custom step and loss logic for a LlamaForCausalLM model, add that in when using CPU or MPS we are always world_size == 1 and local_rank == 0