### PR TITLE
ci: add AWS tags to show github ref and PR num for all jobs

### DIFF
--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -48,7 +48,9 @@ jobs:
           aws-resource-tags: >
             [
               {"Key": "Name", "Value": "instructlab-ci-github-small-runner"},
-              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
+              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
+              {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
+              {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
             ]
   
   e2e:


### PR DESCRIPTION
right now we can see what type of runner and which repository an AWS runner is associated with, but not the associated ref and PR number

see https://github.com/instructlab/instructlab/pull/2183 for reference