### PR TITLE
changes StreamablePopen to return a process and implement listening

### DIFF
--- a/src/instructlab/training/utils.py
+++ b/src/instructlab/training/utils.py
@@ -92,11 +92,14 @@ class StreamablePopen(subprocess.Popen):
         # remove the stderr and stdout from kwargs
         kwargs.pop("stderr", None)
         kwargs.pop("stdout", None)
+        self.output_file = output_file
 
         super().__init__(
             *args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs
         )
-        with open(output_file, "wb") as full_log_file:
+
+    def listen(self):
+        with open(self.output_file, "wb") as full_log_file:
             while True:
                 byte = self.stdout.read(1)
                 if byte:


### PR DESCRIPTION
The original logic wasn't working because StreamablePopen started a process and then listened on the output file instead of returning a process that could be terminated/killed.

This adds 'process.listen' to implement the same behavior as before, but only after the StreamablePopen object has returned a reference to itself. When a KeyboardInterrupt is sent, the process can be terminated and/or killed, and the Exception/Interrupt can be raised.