### PR TITLE
Fix generic chat template saved to tokenizer for generation

### DIFF
--- a/src/instructlab/training/chat_templates/ibm_generic_tmpl.py
+++ b/src/instructlab/training/chat_templates/ibm_generic_tmpl.py
@@ -23,5 +23,8 @@ CHAT_TEMPLATE = (
     "{% elif message['role'] == 'assistant' %}"
     "{{'<|assistant|>' + '\n' + message['content'] + '<|endoftext|>' + ('' if loop.last else '\n')}}"
     "{% endif %}"
+    "{% if loop.last and add_generation_prompt %}"
+    "{{ '<|assistant|>' + '\n' }}"
+    "{% endif %}"
     "{% endfor %}"
 )


### PR DESCRIPTION
Currently, the expected assistant token at the end of existing msgs for generation isn't being appended, due to the condition being omitted in the chat template.

Fixes #233 