### PR TITLE
adds Accelerate full-state (opt, lr_sched, params)

### DIFF
--- a/src/instructlab/training/config.py
+++ b/src/instructlab/training/config.py
@@ -169,7 +169,8 @@ class TrainingArgs(BaseModel):
     warmup_steps: int
     is_padding_free: bool
     random_seed: int = 42
-    checkpoint_at_epoch: bool = False
+    checkpoint_at_epoch: bool = True
+    accelerate_full_state_at_epoch: bool = True
 
     mock_data: Optional[bool] = False
     mock_data_len: int = 0


### PR DESCRIPTION
Saving and reloading for deepspeed.

Todo:

- [ ] Need to save LoRA model correctly
- [ ] choose whether the save the transformers model config + tokenizer with the model.
- [ ] make sure this also handles dolomite correctly
- [ ] run w/ CPU offloading
- [ ] choose how to resume w/ samples_seen and between epochs. e.g. if we save a checkpoint at the end of an epoch, do we always save with the metadata for the next epoch and samples_seen=0?