### PR TITLE
fix: updates sorting logic to correctly compare numbers

### DIFF
--- a/src/instructlab/training/utils.py
+++ b/src/instructlab/training/utils.py
@@ -870,8 +870,13 @@ def load_latest_full_state(args, accelerator) -> None:
     if not output_dir.is_dir():
         return
 
-    # picks checkpoint with the largest number of samples seen, by name.
-    checkpoint_list = sorted(list(output_dir.iterdir()), reverse=True)
+    # picks checkpoint with the largest number of samples by splitting the "samples_NNNN" string on _
+    # and comparing the number at the end of the string
+    checkpoint_list = sorted(
+        list(output_dir.iterdir()),
+        reverse=True,
+        key=lambda x: int(str(x).rsplit("_", maxsplit=1)[-1]),
+    )
 
     if len(checkpoint_list) == 0:
         log_rank_0(


### PR DESCRIPTION
This PR fixes a bug currently present in the checkpoint selection logic,
where the checkpoint names are sorted by string, e.g.:

```py
lst = ["samples_1", "samples_10","samples_19", "samples_2", "samples_9999"]
print(sorted(lst))
> ['samples_1', 'samples_10', 'samples_19', 'samples_2', 'samples_9999']
```

This PR fixes this issue by specifying the `key` parameter such that it now extracts the number at the end and uses it for comparison:

```py
sorted(lst, key=lambda x: int(x.split("_")[-1]), reverse=True)
> ['samples_9999', 'samples_19', 'samples_10', 'samples_2', 'samples_1']
```

Fixes #236 

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
