### PR TITLE
ci: grant HF_TOKEN access to the medium-size E2E CI job

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x1.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x1.yml
@@ -137,6 +137,8 @@ jobs:
 
       - name: Run e2e test
         working-directory: ./instructlab
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           . venv/bin/activate
           ./scripts/e2e-ci.sh -m
@@ -155,6 +157,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Stop EC2 runner
         uses: machulav/ec2-github-runner@fcfb31a5760dad1314a64a0e172b78ec6fc8a17e # v2.3.6
         with:


### PR DESCRIPTION
Will fix issue with model downloads