### PR TITLE
fix: add working directory config to steps in large E2E CI job

### DIFF
--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -107,6 +107,7 @@ jobs:
           gh --version
 
       - name: set default repo
+        working-directory: ./training
         run: |
           gh repo set-default ${{ github.server_url }}/${{ github.repository }}
         env:
@@ -114,6 +115,7 @@ jobs:
 
       - name: Add comment to PR
         if: steps.check_pr.outputs.is_pr == 'true'
+        working-directory: ./training
         run: |
           gh pr comment "${{ steps.check_pr.outputs.pr_or_branch }}" -b "${{ github.workflow }} workflow launched on this PR: [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
         env:
@@ -121,6 +123,7 @@ jobs:
 
       - name: Fetch and checkout PR
         if: steps.check_pr.outputs.is_pr == 'true'
+        working-directory: ./training
         run: |
           gh pr checkout ${{ steps.check_pr.outputs.pr_or_branch }}
         env:
@@ -128,6 +131,7 @@ jobs:
 
       - name: Checkout branch
         if: steps.check_pr.outputs.is_pr == 'false'
+        working-directory: ./training
         run: |
           git checkout ${{ steps.check_pr.outputs.pr_or_branch }}
 


### PR DESCRIPTION
https://github.com/instructlab/training/actions/runs/11485349195/job/31965270089 revealed an issue with where the `gh` command was being run - this PR ensures all of these steps are run within the checked-out `training` repo on the runner