### PR TITLE
deps: change hf accelerate bound, add requirements-hpu.txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ package-dir = { "" = "src" }
 dependencies = { file = ["requirements.txt"] }
 optional-dependencies.cuda = { file = ["requirements-cuda.txt"] }
 optional-dependencies.rocm = { file = ["requirements-rocm.txt"] }
+optional-dependencies.hpu = { file = ["requirements-hpu.txt"] }
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,2 +1,5 @@
 flash-attn>=2.4.0
 bitsandbytes>=0.43.1
+
+# required for FSDP updates
+accelerate>=0.34.2

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -1,0 +1,2 @@
+# required for optimum-habana's deps
+accelerate>=0.33.0

--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -1,1 +1,3 @@
 flash-attn>=2.6.2,<2.7.0
+# required for FSDP updates
+accelerate>=0.34.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ py-cpuinfo
 # replace custom pytorch images with the 2.3.0
 torch>=2.3.0a0
 transformers>=4.45.2
-accelerate>=0.34.2
+
 datasets>=2.15.0
 numba
 # Note: numpy ranges copied from instructlab/instructlab
@@ -22,6 +22,6 @@ trl>=0.9.4
 peft
 pydantic>=2.7.0
 
-# deepspeed needs to be at the bottom or it'll break during installation
+# deepspeed needs to be at the end or it'll break stuff.
 deepspeed>=0.14.3
 aiofiles>=23.2.1


### PR DESCRIPTION
Adds `requirements-hpu.txt` file and `optional-dependencies.hpu` to pyproject.toml

Sets lower bound for `accelerate` for rocm, cuda, and hpu separately.

For HPU, sets `accelerate>=0.33.0` because `optimum-habana` requires this.

For CUDA/ROCm sets `accelerate=>0.34.2` because accelerate got FSDP patches that we need.
