### PR TITLE
chore: move token classes into chat templates

### DIFF
--- a/src/instructlab/training/chat_templates/ibm_generic_tmpl.py
+++ b/src/instructlab/training/chat_templates/ibm_generic_tmpl.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # First Party
-from instructlab.training.tokenizer_utils import SpecialTokens, TokenInfo
+from instructlab.training.chat_templates.utils import SpecialTokens, TokenInfo
 
 SPECIAL_TOKENS = SpecialTokens(
     start_role=TokenInfo("<|start_of_role|>", add_to_tokenizer=True),

--- a/src/instructlab/training/chat_templates/ibm_legacy_tmpl.py
+++ b/src/instructlab/training/chat_templates/ibm_legacy_tmpl.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # First Party
-from instructlab.training.tokenizer_utils import SpecialTokens, TokenInfo
+from instructlab.training.chat_templates.utils import SpecialTokens, TokenInfo
 
 SPECIAL_TOKENS = SpecialTokens(
     system=TokenInfo("<|system|>", add_to_tokenizer=True),

--- a/src/instructlab/training/chat_templates/mistral_tmpl.py
+++ b/src/instructlab/training/chat_templates/mistral_tmpl.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # First Party
-from instructlab.training.tokenizer_utils import SpecialTokens, TokenInfo
+from instructlab.training.chat_templates.utils import SpecialTokens, TokenInfo
 
 SPECIAL_TOKENS = SpecialTokens(
     bos=TokenInfo("<s>", add_to_tokenizer=True),

--- a/src/instructlab/training/chat_templates/utils.py
+++ b/src/instructlab/training/chat_templates/utils.py
@@ -1,0 +1,29 @@
+# Standard
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class TokenInfo:
+    token: str
+    add_to_tokenizer: bool = False
+
+
+@dataclass
+class SpecialTokens:
+    system: TokenInfo = field(default_factory=lambda: TokenInfo(""))
+    user: TokenInfo = field(default_factory=lambda: TokenInfo(""))
+    assistant: TokenInfo = field(default_factory=lambda: TokenInfo(""))
+    eos: TokenInfo = field(default_factory=lambda: TokenInfo(""))
+    pad: TokenInfo = field(default_factory=lambda: TokenInfo(""))
+    bos: TokenInfo = field(default_factory=lambda: TokenInfo(""))
+    start_role: TokenInfo = field(default_factory=lambda: TokenInfo(""))
+    end_role: TokenInfo = field(default_factory=lambda: TokenInfo(""))
+    tool: TokenInfo = field(default_factory=lambda: TokenInfo(""))
+
+    def get_tokens_to_add(self) -> List[str]:
+        return [
+            token_info.token
+            for token_info in self.__dict__.values()
+            if token_info.add_to_tokenizer and token_info.token
+        ]

--- a/src/instructlab/training/tokenizer_utils.py
+++ b/src/instructlab/training/tokenizer_utils.py
@@ -1,40 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Standard
-from dataclasses import dataclass, field
-from typing import List
-
 # Third Party
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 # First Party
 from instructlab.training.utils import log_rank_0
-
-
-@dataclass
-class TokenInfo:
-    token: str
-    add_to_tokenizer: bool = False
-
-
-@dataclass
-class SpecialTokens:
-    system: TokenInfo = field(default_factory=lambda: TokenInfo(""))
-    user: TokenInfo = field(default_factory=lambda: TokenInfo(""))
-    assistant: TokenInfo = field(default_factory=lambda: TokenInfo(""))
-    eos: TokenInfo = field(default_factory=lambda: TokenInfo(""))
-    pad: TokenInfo = field(default_factory=lambda: TokenInfo(""))
-    bos: TokenInfo = field(default_factory=lambda: TokenInfo(""))
-    start_role: TokenInfo = field(default_factory=lambda: TokenInfo(""))
-    end_role: TokenInfo = field(default_factory=lambda: TokenInfo(""))
-    tool: TokenInfo = field(default_factory=lambda: TokenInfo(""))
-
-    def get_tokens_to_add(self) -> List[str]:
-        return [
-            token_info.token
-            for token_info in self.__dict__.values()
-            if token_info.add_to_tokenizer and token_info.token
-        ]
 
 
 def setup_tokenizer(


### PR DESCRIPTION
moves base classes used in the chat templates out of `tokenizer_utils.py` so that chat templates can be easily imported without pulling in unnecessary imports from other parts of the code 