### PR TITLE
fix: incorrect enum selection

### DIFF
--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -775,7 +775,7 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
     )
 
     # deepspeed options
-    if train_args.distributed_backend == DistributedBackend.DeepSpeed:
+    if train_args.distributed_backend == DistributedBackend.DEEPSPEED:
         if not FusedAdam:
             raise ImportError(
                 "DeepSpeed was selected as the distributed backend, but FusedAdam could not be imported. Please double-check that DeepSpeed is installed correctly"


### PR DESCRIPTION
PR #291 introduced extra logic for handling DeepSpeed options selectively when we can't import specific portions, however a bug had made it through where the enum that references backends was accessing the incorrect deepspeed reference.


Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
