### PR TITLE
feat: add toggle to pick legacy chat tmpl for granite

### DIFF
--- a/src/instructlab/training/config.py
+++ b/src/instructlab/training/config.py
@@ -156,6 +156,9 @@ class TrainingArgs(BaseModel):
         os.path.dirname(__file__), "chat_templates/ibm_generic_tmpl.py"
     )
 
+    # this field determines if ibm_legacy_tmpl should be used instead
+    use_legacy_tmpl: bool = False
+
     # this field specifies the filepath to the training dataset before processing
     data_path: str
     ckpt_output_dir: str

--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -691,6 +691,12 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
     """
     check_valid_train_args(train_args)
 
+    # switch out generic tmpl for legacy tmpl if requested
+    if train_args.use_legacy_tmpl:
+        train_args.chat_tmpl_path = os.path.join(
+            os.path.dirname(__file__), "chat_templates/ibm_legacy_tmpl.py"
+        )
+
     if train_args.process_data:
         dp.main(
             DataProcessArgs(


### PR DESCRIPTION
This PR adds a bool to train_args that allows consumers to specifically request the legacy ibm template if necessary for training 