### PR TITLE
adds pytest to tox via `py3-unit`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tox]
-# py3-unit runs unit tests with 'python3'
-# py311-unit runs the same tests with 'python3.11'
-envlist = ruff, lint, mypy, spellcheck
+envlist = ruff, lint, mypy, spellcheck, py3-unit
 minversion = 4.4
 
 [testenv]
@@ -18,6 +16,14 @@ deps =
 
 [testenv:py3]
 basepython = python3.11
+
+[testenv:py3-unit]
+description = run unit tests with pytest
+commands = {envpython} -m pytest tests {posargs}
+# NOTE: {posargs} is a placeholder for input positional arguments
+# such as `tox -e py3-unit -- --pdb` if we wanted to run pytest with pdb enabled.
+# `--` delimits flags that are meant for tox vs. those that are positional arguments for
+# the command that's being run in the environment.
 
 # format, check, and linting targets don't build and install the project to
 # speed up testing.


### PR DESCRIPTION
We didn't have a pytest entrypoint available in our tox.ini file. This allows us to write unit tests inside the `tests` directory.

Solves: https://github.com/instructlab/training/issues/377