### PR TITLE
changes Fast unit CI runner, m8g->m7i

### DIFF
--- a/.github/workflows/unittesting-ci-nvidia.yaml
+++ b/.github/workflows/unittesting-ci-nvidia.yaml
@@ -19,7 +19,7 @@ on:
 
 env:
   pytest_mark: "fast"
-  ec2_runner_variant: "m8g.xlarge" # 4 Graviton CPU, 16GB RAM
+  ec2_runner_variant: "m7i.xlarge" # 4 Xeon CPU, 16GB RAM
 
 jobs:
   start-ec2-runner:


### PR DESCRIPTION
m8g runner not available in us-east-2

Current CI broken because runner instance not available.

Signed-off-by: James Kunstle <jkunstle@redhat.com>
