### PR TITLE
fix: Update ec2 instance type in unit test workflow file

### DIFF
--- a/.github/workflows/unittesting-ci-nvidia.yaml
+++ b/.github/workflows/unittesting-ci-nvidia.yaml
@@ -13,9 +13,11 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
   push:
+    # TEMPORARILY ADDING TESTING BRANCH. WILL REMOVE.
     branches:
       - "main"
       - "release-**"
+      - "fix-unit-test-workflow-file"
 
 env:
   pytest_mark: "fast"
@@ -26,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
 
     steps:
       - name: "Harden runner"
@@ -48,13 +50,15 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ${{ vars.AWS_EC2_AMI }}
-          ec2-instance-type: ${{ vars.AWS_REGION }}
+          # TODO: Update the EC2 instance type to use the EC2 runner variant when GPU calls are mocked
+          # ec2-instance-type: ${{ env.ec2_runner_variant }}
+          ec2-instance-type: g4dn.12xlarge
           subnet-id: subnet-024298cefa3bedd61
           security-group-id: sg-06300447c4a5fbef3
           iam-role-name: instructlab-ci-runner
           aws-resource-tags: >
             [
-            {"Key": "Name", "Value": "instructlab-ci-github-large-runner"},
+            {"Key": "Name", "Value": "instructlab-ci-github-unit-test-runner"},
             {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
             {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
             {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
@@ -104,6 +108,7 @@ jobs:
 
       - name: "Run unit tests with Tox and Pytest"
         run: |
+          . venv/bin/activate
           tox -e py3-unit -- -m ${{env.pytest_mark}}
 
       - name: "Show disk utilization AFTER tests"
@@ -120,6 +125,7 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.1
         with:
           egress-policy: audit
+
       - name: "Configure AWS credentials"
         uses: "aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502" # v4.0.2
         with:
@@ -128,10 +134,11 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: "Stop EC2 runner"
-        id: start-ec2-runner
         uses: machulav/ec2-github-runner@1827d6ca7544d7044ddbd2e9360564651b463da2 # v2.3.7
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           label: ${{ needs.start-ec2-runner.outputs.label }}
-          ec2-instance-type: ${{ env.ec2_runner_variant }}
+          ec2-instance-id: ${{ needs.start-ec2-runner.outputs.ec2-instance-id }}
+          # TODO: Update the EC2 instance type to use the EC2 runner variant when GPU calls are mocked
+          # ec2-instance-type: ${{ env.ec2_runner_variant }}


### PR DESCRIPTION
Resolves #394

Unit tests currently fail due to a minor configuration issue in one of our workflow files. This PR aims to resolve the typo. See referenced git issue.