### PR TITLE
fixes unit ec2-name

### DIFF
--- a/.github/workflows/unittesting-ci-nvidia.yaml
+++ b/.github/workflows/unittesting-ci-nvidia.yaml
@@ -48,7 +48,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ${{ vars.AWS_EC2_AMI }}
-          ec2-instance-type: ${{ vars.AWS_REGION }}
+          ec2-instance-type: ${{ env.ec2_runner_variant }}
           subnet-id: subnet-024298cefa3bedd61
           security-group-id: sg-06300447c4a5fbef3
           iam-role-name: instructlab-ci-runner


### PR DESCRIPTION
used the wrong environment variable for setting up the instance that we'd like to run our unit tests with.