### PR TITLE
Refactor + add unit and smoke testing workflows.

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -15,10 +15,11 @@ on:
       - release-*
     paths:
       # note this should match the merging criteria in 'mergify.yml'
-      - '**.py'
-      - 'pyproject.toml'
-      - 'requirements**.txt'
-      - '.github/workflows/e2e-nvidia-l4-x1.yml' # This workflow
+      - "!tests/**" # we don't need to run e2e if we're just changing the tests.
+      - "**.py"
+      - "pyproject.toml"
+      - "requirements**.txt"
+      - ".github/workflows/e2e-nvidia-l4-x1.yml" # This workflow
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -72,7 +73,7 @@ jobs:
               {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
               {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
             ]
-  
+
   e2e-medium-test:
     needs:
       - start-medium-ec2-runner
@@ -155,7 +156,7 @@ jobs:
           . venv/bin/activate
           # set preserve to true so we can retain the logs
           ./scripts/e2e-ci.sh -mp
-          
+
           # HACK(osilkin): The above test runs the medium workflow test which does not actually test the training library.
           #                Therefore we must disable the upload of the training logs, as they will not exist in the same location.
           # we know that the file will be named something like f"/training_params_and_metrics_global{os.environ['RANK']}.jsonl" in python
@@ -202,7 +203,7 @@ jobs:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           label: ${{ needs.start-medium-ec2-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-medium-ec2-runner.outputs.ec2-instance-id }}
-      
+
       # - name: Download loss data
       #   id: download-logs
       #   uses: actions/download-artifact@v4
@@ -213,12 +214,12 @@ jobs:
       # - name: Install dependencies
       #   run: |
       #     pip install -r requirements-dev.txt
-      
+
       # - name: Try to upload to s3
       #   id: upload-s3
       #   continue-on-error: true
       #   run: |
-      #     output_file='./test.md' 
+      #     output_file='./test.md'
       #     python scripts/create-loss-graph.py  \
       #       --log-file "${{ steps.download-logs.outputs.download-path }}/training-log.jsonl" \
       #       --output-file "${output_file}" \

--- a/.github/workflows/reusable-start-ec2-runner.yaml
+++ b/.github/workflows/reusable-start-ec2-runner.yaml
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "[Reusable] Start EC2 self-hosted runner."
+
+on:
+  workflow_call:
+    inputs:
+      aws_region:
+        description: "AWS datacenter identification; e.g. `us-west-2`"
+        type: string
+        required: true
+      aws_ami:
+        description: "AWS EC2 instance AMI ID"
+        type: string
+        required: true
+      aws_ec2_runner_variant:
+        description: "AWS EC2 instance type; e.g. `m7i.xlarge`"
+        type: string
+        required: true
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      GITHUB_PERSONAL_ACCESS_TOKEN:
+        required: true
+    outputs:
+      runner_label:
+        value: ${{jobs.start-ec2-runner.outputs.label}}
+      runner_instance_id:
+        value: ${{jobs.start-ec2-runner.outputs.ec2-instance-id}}
+
+# (jkunstle) NOTES:
+# 1. This workflow's permissions don't seem relevant since it's reusable
+#   concurrency protections seem irrelevant because it could be reused by other
+# 2. workflows that need to do so.
+# 3. not sure if I need to edit the aws-resource-tags if this is a reusable workflow.
+#   that might be non-generic information that this workflow should take as input.
+
+jobs:
+  start-ec2-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id}}
+
+    steps:
+      - name: "Harden runner"
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: "Configure AWS credentials"
+        uses: "aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502" # v4.0.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID}}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: "Start EC2 runner"
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@28fbe1c4d7d9ba74134ca5ebc559d5b0a989a856 # v2.3.8
+        with:
+          mode: start
+          github-token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN}}
+          ec2-image-id: ${{ inputs.aws_ami }}
+          ec2-instance-type: ${{ inputs.aws_ec2_runner_variant}}
+          subnet-id: subnet-024298cefa3bedd61
+          security-group-id: sg-06300447c4a5fbef3
+          iam-role-name: instructlab-ci-runner
+          aws-resource-tags: >
+            [
+            {"Key": "Name", "Value": "instructlab-ci-github-unittest-runner"},
+            {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
+            {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
+            {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
+            ]

--- a/.github/workflows/reusable-stop-ec2-runner.yaml
+++ b/.github/workflows/reusable-stop-ec2-runner.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "[Reusable] Stop EC2 self-hosted runner."
+
+on:
+  workflow_call:
+    inputs:
+      aws_region:
+        description: "AWS datacenter identification; e.g. `us-west-2`"
+        type: string
+        required: true
+      aws_ec2_runner_instance_id:
+        description: "AWS EC2 ID for instance that's running"
+        type: string
+        required: true
+      aws_ec2_runner_label:
+        description: "AWS EC2 instance label for instance that's running"
+        type: string
+        required: true
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      GITHUB_PERSONAL_ACCESS_TOKEN:
+        required: true
+
+jobs:
+  stop-ec2-runner:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Harden runner"
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: "Configure AWS credentials"
+        uses: "aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502" # v4.0.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID}}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: "Stop EC2 runner"
+        uses: machulav/ec2-github-runner@28fbe1c4d7d9ba74134ca5ebc559d5b0a989a856 # v2.3.8
+        with:
+          mode: stop
+          github-token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN}}
+          label: ${{ inputs.aws_ec2_runner_label }}
+          ec2-instance-id: ${{ inputs.aws_ec2_runner_instance_id }}

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: "Run smoke tests via Tox::pytest"
+# These tests will be long running and require accelerated hardware.
+# They will help to verify that the library is *functionally* correct but
+# will not try to verify that the libary is *correct*.
+
+on:
+  # TEMP - only runs when manually invoked
+  # and only runs against branches in the repo.
+  workflow_dispatch:
+    inputs:
+      branch:
+        type: string
+        default: main
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  start-ec2-runner:
+    uses: ./.github/workflows/reusable-start-ec2-runner.yaml
+    with:
+      aws_region: ${{vars.AWS_REGION}}
+      aws_ami: ${{vars.AWS_EC2_AMI}}
+      aws_ec2_runner_variant: ${{vars.SMOKETEST_EC2_INSTANCE_TYPE}} # requires accelerators
+    secrets: inherit
+
+  run-smoke-tests:
+    needs:
+      - start-ec2-runner
+    runs-on: ${{needs.start-ec2-runner.outputs.runner_label}}
+    # It is important that this job has no write permissions and has
+    # no access to any secrets. This part is where we are running
+    # untrusted code from PRs.
+    permissions: {}
+    steps:
+      - name: "Harden runner"
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: "Install packages"
+        run: |
+          cat /etc/os-release
+          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+
+      - name: "Verify cuda environment is setup"
+        run: |
+          export CUDA_HOME="/usr/local/cuda"
+          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
+          export PATH="$PATH:$CUDA_HOME/bin"
+          nvidia-smi
+
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{inputs.branch}}
+
+      # installs in $GITHUB_WORKSPACE/venv.
+      # only has to install Tox because Tox will do the other virtual environment management.
+      - name: "Setup Python virtual environment"
+        run: |
+          python3.11 -m venv --upgrade-deps venv
+          . venv/bin/activate
+          pip install tox
+
+      - name: "Show disk utilization BEFORE tests"
+        run: |
+          df -h
+
+      - name: "Run unit tests with Tox and Pytest"
+        run: |
+          source venv/bin/activate
+          tox -e py3-smoke
+
+      - name: "Show disk utilization AFTER tests"
+        run: |
+          df -h
+
+  stop-ec2-runner:
+    needs:
+      - start-ec2-runner
+      - run-smoke-tests
+    if: ${{ always() }}
+    uses: ./.github/workflows/reusable-stop-ec2-runner.yaml
+    with:
+      aws_region: ${{vars.AWS_REGION}}
+      aws_ec2_runner_label: ${{needs.start-ec2-runner.outputs.runner_label}}
+      aws_ec2_runner_instance_id: ${{needs.start-ec2-runner.outputs.runner_instance_id}}
+    secrets: inherit

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -38,53 +38,19 @@ defaults:
   run:
     shell: bash
 
-env:
-  pytest_mark: "fast"
-  ec2_runner_variant: "m7i.xlarge" # 4 Xeon CPU, 16GB RAM
-
 jobs:
   start-ec2-runner:
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id}}
-
-    steps:
-      - name: "Harden runner"
-        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.1
-        with:
-          egress-policy: audit
-
-      - name: "Configure AWS credentials"
-        uses: "aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502" # v4.0.2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: "Start EC2 runner"
-        id: start-ec2-runner
-        uses: machulav/ec2-github-runner@28fbe1c4d7d9ba74134ca5ebc559d5b0a989a856 # v2.3.8
-        with:
-          mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ${{ vars.AWS_EC2_AMI }}
-          ec2-instance-type: ${{ env.ec2_runner_variant }}
-          subnet-id: subnet-024298cefa3bedd61
-          security-group-id: sg-06300447c4a5fbef3
-          iam-role-name: instructlab-ci-runner
-          aws-resource-tags: >
-            [
-            {"Key": "Name", "Value": "instructlab-ci-github-unittest-runner"},
-            {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
-            {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
-            {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
-            ]
+    uses: ./.github/workflows/reusable-start-ec2-runner.yaml
+    with:
+      aws_region: ${{vars.AWS_REGION}}
+      aws_ami: ${{vars.AWS_EC2_AMI}}
+      aws_ec2_runner_variant: ${{vars.UNITTEST_EC2_INSTANCE_TYPE}}
+    secrets: inherit
 
   run-unit-tests:
     needs:
       - start-ec2-runner
-    runs-on: ${{needs.start-ec2-runner.outputs.label}}
+    runs-on: ${{needs.start-ec2-runner.outputs.runner_label}}
     # It is important that this job has no write permissions and has
     # no access to any secrets. This part is where we are running
     # untrusted code from PRs.
@@ -120,7 +86,7 @@ jobs:
       - name: "Run unit tests with Tox and Pytest"
         run: |
           source venv/bin/activate
-          tox -e py3-unit -- -m ${{env.pytest_mark}}
+          tox -e py3-unit
 
       - name: "Show disk utilization AFTER tests"
         run: |
@@ -130,25 +96,10 @@ jobs:
     needs:
       - start-ec2-runner
       - run-unit-tests
-    runs-on: ubuntu-latest
     if: ${{ always() }}
-    steps:
-      - name: "Harden runner"
-        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.1
-        with:
-          egress-policy: audit
-
-      - name: "Configure AWS credentials"
-        uses: "aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502" # v4.0.2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: "Stop EC2 runner"
-        uses: machulav/ec2-github-runner@28fbe1c4d7d9ba74134ca5ebc559d5b0a989a856 # v2.3.8
-        with:
-          mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          label: ${{ needs.start-ec2-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-ec2-runner.outputs.ec2-instance-id }}
+    uses: ./.github/workflows/reusable-stop-ec2-runner.yaml
+    with:
+      aws_region: ${{vars.AWS_REGION}}
+      aws_ec2_runner_label: ${{needs.start-ec2-runner.outputs.runner_label}}
+      aws_ec2_runner_instance_id: ${{needs.start-ec2-runner.outputs.runner_instance_id}}
+    secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,3 +107,8 @@ exclude = [
 ]
 # honor excludes by not following there through imports
 follow_imports = "silent"
+
+[tool.pytest.ini_options]
+markers = [
+  "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ ipython
 ipykernel
 jupyter
 
+huggingface_hub

--- a/tests/test_smoke/test_train.py
+++ b/tests/test_smoke/test_train.py
@@ -1,0 +1,228 @@
+# Standard
+import os
+import pathlib
+import shutil
+import sys
+import tempfile
+
+# Third Party
+from transformers import AutoModelForCausalLM
+import huggingface_hub
+import pytest
+
+# First Party
+from instructlab.training import data_process
+from instructlab.training.config import (
+    DataProcessArgs,
+    DistributedBackend,
+    TorchrunArgs,
+    TrainingArgs,
+)
+from instructlab.training.main_ds import run_training
+
+MINIMAL_TRAINING_ARGS = {
+    "max_seq_len": 140,  # this config fits nicely on 4xL40s and may need modification for other setups
+    "max_batch_len": 15000,
+    "num_epochs": 1,
+    "effective_batch_size": 3840,
+    "save_samples": 0,
+    "learning_rate": 1e-4,
+    "warmup_steps": 1,
+    "random_seed": 43,
+    "use_dolomite": False,
+    "is_padding_free": False,
+    "checkpoint_at_epoch": True,
+    "accelerate_full_state_at_epoch": True,
+    "process_data": False,  # expect that incoming data has already been prepared and cached.
+    "disable_flash_attn": False,
+}
+
+DEFAULT_TORCHRUN_ARGS = {
+    "nproc_per_node": 4,  # TODO: this is runner-specific. Should parametrize from environment.
+    "nnodes": 1,
+    "node_rank": 0,
+    "rdzv_id": 123,
+    "rdzv_endpoint": "127.0.0.1:12345",
+}
+
+REFERENCE_TEST_MODEL = "instructlab/granite-7b-lab"
+RUNNER_CPUS_EXPECTED = 4
+
+# matrix of training environments we'd like to test
+DIST_BACKEND_FRAMEWORKS = ["fsdp", "deepspeed"]
+USE_DOLOMITE = [True, False]
+CPU_OFFLOADING = [True, False]
+USE_LORA = [True, False]
+
+
+@pytest.fixture(scope="module")
+def custom_tmp_path():
+    temp_dir = tempfile.mkdtemp()
+
+    temp_path = pathlib.Path(temp_dir)
+
+    yield temp_path
+
+    shutil.rmtree(temp_path)
+
+
+@pytest.fixture(scope="function")
+def checkpoint_dir(custom_tmp_path: pathlib.Path) -> pathlib.Path:
+    """
+    Creates a 'checkpoints' directory for each test and deletes it afterward.
+    """
+    ckpt_dir = custom_tmp_path / "checkpoints"
+    ckpt_dir.mkdir()
+
+    yield ckpt_dir
+
+    shutil.rmtree(ckpt_dir)
+
+
+@pytest.fixture(scope="module")
+def prepared_data_dir(custom_tmp_path: pathlib.Path) -> pathlib.Path:
+    data_file_dir = custom_tmp_path / "prepared_data"
+    data_file_dir.mkdir()
+
+    return data_file_dir
+
+
+@pytest.fixture(scope="module")
+def cached_model_dir(custom_tmp_path: pathlib.Path) -> pathlib.Path:
+    model_dir = custom_tmp_path / "model"
+    model_dir.mkdir()
+    return model_dir
+
+
+@pytest.fixture(scope="module")
+def cached_test_model(cached_model_dir: pathlib.Path) -> pathlib.Path:
+    """
+    Downloads test model artifacts to temporary cache from HF repo.
+    Assumes that the artifacts for the tokenizer are in the same repo.
+
+    Some interesting behavior:
+    (1) if model is already cached in $HF_HOME/hub/<model> the parameter blobs
+        will be copied into the specified `local_dir`. If some remote
+        files (like paper.pdf or tokenizer.config) aren't in the HF_HOME
+        cache, they'll be pulled and stored in the `local_dir` cache.
+    (2) if model is NOT already cached in $HF_HOME/hub/<model>, a reference will
+        still be created to it but the downloaded artifacts will not be copied
+        back to the HF_HOME cache from the `local_dir`.
+    """
+
+    huggingface_hub.snapshot_download(
+        token=os.getenv("HF_TOKEN", None),
+        repo_id=REFERENCE_TEST_MODEL,
+        local_dir=cached_model_dir,
+    )
+
+    return cached_model_dir
+
+
+def this_file_path() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve()
+
+
+def data_in_repo_path() -> pathlib.Path:
+    current_file_path = this_file_path()
+    data_in_repo_path = (
+        current_file_path.parents[2] / "sample-data" / "train_all_pruned_SDG.jsonl"
+    )
+    return data_in_repo_path
+
+
+def chat_template_in_repo_path() -> pathlib.Path:
+    current_file_path = this_file_path()
+    chat_template_path = (
+        current_file_path.parents[2]
+        / "src"
+        / "instructlab"
+        / "training"
+        / "chat_templates"
+        / "ibm_generic_tmpl.py"
+    )
+    return chat_template_path
+
+
+# TODO: This uses our data preprocessing utility which is not, itself, well tested.
+# need to write tests for this as well.
+@pytest.fixture(scope="module")
+def cached_training_data(
+    prepared_data_dir: pathlib.Path, cached_test_model: pathlib.Path
+) -> pathlib.Path:
+    """Renders test data in model template, tokenizes, and saves to fs"""
+
+    data_in_repo = data_in_repo_path()
+    chat_template = chat_template_in_repo_path()
+
+    data_process_args = DataProcessArgs(
+        data_output_path=str(prepared_data_dir),
+        data_path=str(data_in_repo),
+        max_seq_len=MINIMAL_TRAINING_ARGS["max_seq_len"],
+        model_path=str(cached_test_model),
+        chat_tmpl_path=str(chat_template),
+        num_cpu_procs=RUNNER_CPUS_EXPECTED,
+    )
+
+    data_process.main(data_process_args)
+
+    return prepared_data_dir / "data.jsonl"
+
+
+@pytest.mark.skip
+@pytest.mark.slow
+def test_basic_training_run(
+    cached_test_model: pathlib.Path,
+    cached_training_data: pathlib.Path,
+    checkpoint_dir: pathlib.Path,
+    prepared_data_dir: pathlib.Path,
+) -> None:
+    """
+    Used for isolated test development. Skipped when not in use.
+    """
+
+    train_args = TrainingArgs(
+        model_path=str(cached_test_model),
+        data_path=str(cached_training_data),
+        data_output_dir=str(prepared_data_dir),
+        ckpt_output_dir=str(checkpoint_dir),
+        **MINIMAL_TRAINING_ARGS,
+    )
+
+    torch_args = TorchrunArgs(**DEFAULT_TORCHRUN_ARGS)
+
+    run_training(torch_args=torch_args, train_args=train_args)
+    assert True
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("dist_backend", DIST_BACKEND_FRAMEWORKS)
+@pytest.mark.parametrize("cpu_offload", CPU_OFFLOADING)
+def test_training_feature_matrix(
+    cached_test_model: pathlib.Path,
+    cached_training_data: pathlib.Path,
+    checkpoint_dir: pathlib.Path,
+    prepared_data_dir: pathlib.Path,
+    cpu_offload: bool,
+    dist_backend: str,
+) -> None:
+    train_args = TrainingArgs(
+        model_path=str(cached_test_model),
+        data_path=str(cached_training_data),
+        data_output_dir=str(prepared_data_dir),
+        ckpt_output_dir=str(checkpoint_dir),
+        **MINIMAL_TRAINING_ARGS,
+    )
+
+    train_args.distributed_backend = DistributedBackend(dist_backend)
+    if DistributedBackend.FSDP.value == dist_backend:
+        train_args.fsdp_options.cpu_offload_params = cpu_offload
+    else:
+        pytest.xfail("DeepSpeed not currently functional. OOMs during backprop.")
+        if cpu_offload:
+            pytest.xfail("DeepSpeed CPU Adam isn't currently building correctly")
+        train_args.deepspeed_options.cpu_offload_optimizer = cpu_offload
+
+    torch_args = TorchrunArgs(**DEFAULT_TORCHRUN_ARGS)
+
+    run_training(torch_args=torch_args, train_args=train_args)

--- a/tests/test_unit/test_init.py
+++ b/tests/test_unit/test_init.py
@@ -2,6 +2,5 @@
 import pytest
 
 
-@pytest.mark.fast
 def test_fake():
     assert True

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,15 @@ basepython = python3.11
 
 [testenv:py3-unit]
 description = run unit tests with pytest
-commands = {envpython} -m pytest tests {posargs}
+passenv =
+	HF_HOME
+deps = 
+    pytest
+    pytest-asyncio
+    pytest-cov
+    pytest-html
+    -r requirements-dev.txt
+commands = {envpython} -m pytest tests/test_unit {posargs}
 # NOTE: {posargs} is a placeholder for input positional arguments
 # such as `tox -e py3-unit -- --pdb` if we wanted to run pytest with pdb enabled.
 # `--` delimits flags that are meant for tox vs. those that are positional arguments for
@@ -27,6 +35,19 @@ commands = {envpython} -m pytest tests {posargs}
 
 # format, check, and linting targets don't build and install the project to
 # speed up testing.
+[testenv:py3-smoke]
+description = run accelerated smoke tests with pytest
+passenv =
+	HF_HOME
+deps = 
+    pytest
+    pytest-asyncio
+    pytest-cov
+    pytest-html
+    -r requirements-dev.txt
+    -r requirements-cuda.txt
+commands = {envpython} -m pytest tests/test_smoke {posargs}
+
 [testenv:lint]
 description = lint with pylint
 basepython = {[testenv:py3]basepython}


### PR DESCRIPTION
This PR does two things:
1. refactors the existing actions workflow for unit-test.yaml to call two new reusable workflows for starting and stopping an ec2 runner.
2. adds a smoke-test.yaml workflow that's very similar to unit-test.yaml but calls a different tox+pytest path and requires a cuda runner.