### PR TITLE
ci: Don't require secrets in medium e2e test

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -149,9 +149,6 @@ jobs:
 
       - name: Run e2e test
         working-directory: ./instructlab
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           . venv/bin/activate
           # set preserve to true so we can retain the logs


### PR DESCRIPTION
This removes any usage of secrets in the medium e2e