### PR TITLE
fix: model.forward now accepts return_dict via kwargs

### DIFF
--- a/src/instructlab/training/utils.py
+++ b/src/instructlab/training/utils.py
@@ -396,16 +396,16 @@ def convert_loss_to_reduce_sum(model, use_dolomite=False):
             **deprecated_arguments,
         ):
             output = model.__original_forward__(
-                input_ids,
-                attention_mask,
-                position_ids,
-                past_key_values,
-                inputs_embeds,
-                labels,
-                use_cache,
-                output_attentions,
-                output_hidden_states,
-                return_dict,
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                inputs_embeds=inputs_embeds,
+                labels=labels,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                output_hidden_states=output_hidden_states,
+                return_dict=return_dict,
             )
 
             return_dict = isinstance(output, dict)


### PR DESCRIPTION
Since https://github.com/huggingface/transformers/pull/36794 it handles
the return_dict with can_return_tuple decorator that expects the
argument to be passed as kwarg.

Without the patch, instructlab functional tests fail with:

AttributeError: 'bool' object has no attribute 'unsqueeze'

This is because the passed return_dict argument is incorrectly
interpreted as cache_position.

Of course, the way the model forward method is overridden here is quite
problematic and would benefit from a refactor. This patch is a stop-gap
to fix the CI with minimal changes.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
