### PR TITLE
change pytest targets. `test-unit` and `test-smoke` to `unit` and `smoke`

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -62,7 +62,7 @@ jobs:
             [
             {"Key": "Name", "Value": "instructlab-ci-github-smoketest-runner"},
             {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
-            {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
+            {"Key": "GitHubRef", "Value": "${{ github.ref }}"}
             ]
 
   run-smoke-tests:

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     pytest-cov
     pytest-html
     -r requirements-dev.txt
-commands = {envpython} -m pytest tests/test_unit {posargs}
+commands = {envpython} -m pytest tests/unit {posargs}
 # NOTE: {posargs} is a placeholder for input positional arguments
 # such as `tox -e py3-unit -- --pdb` if we wanted to run pytest with pdb enabled.
 # `--` delimits flags that are meant for tox vs. those that are positional arguments for
@@ -42,7 +42,7 @@ deps =
     pytest-asyncio
     -r requirements-dev.txt
     -r requirements-cuda.txt
-commands = {envpython} -m pytest tests/test_smoke {posargs}
+commands = {envpython} -m pytest tests/smoke {posargs}
 
 # format, check, and linting targets don't build and install the project to
 # speed up testing.


### PR DESCRIPTION
Fixes tailing `unit` tests, will fix `smoke` tests when they're able to run