### PR TITLE
moves deepspeed requirements into their own file; add deepspeed extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = { file = ["requirements.txt"] }
 optional-dependencies.cuda = { file = ["requirements-cuda.txt"] }
 optional-dependencies.rocm = { file = ["requirements-rocm.txt"] }
 optional-dependencies.hpu = { file = ["requirements-hpu.txt"] }
+optional-dependencies.deepspeed = { file = ["requirements-deepspeed.txt"] }
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,9 +1,6 @@
 flash-attn>=2.4.0
 bitsandbytes>=0.43.1
 
-# available as an option for NVIDIA, FSDP still default
-deepspeed>=0.14.3
-
 # required for FSDP updates
 accelerate>=0.34.2,<1.1.0
 

--- a/requirements-deepspeed.txt
+++ b/requirements-deepspeed.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+deepspeed>=0.14.3


### PR DESCRIPTION
users may not want to install deepspeed when they install the cuda requirements. this moves DeepSpeed into its own requirements file so if the user wants to install DeepSpeed, they can do so with:

`pip3 install instructlab-training[cuda,deepspeed]`