### PR TITLE
ci: don't waste ec2 resources on unit tests

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -43,48 +43,8 @@ env:
   ec2_runner_variant: "m7i.xlarge" # 4 Xeon CPU, 16GB RAM
 
 jobs:
-  start-ec2-runner:
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id}}
-
-    steps:
-      - name: "Harden runner"
-        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.10.1
-        with:
-          egress-policy: audit
-
-      - name: "Configure AWS credentials"
-        uses: "aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722" # v4.1.0
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: "Start EC2 runner"
-        id: start-ec2-runner
-        uses: machulav/ec2-github-runner@a8c20fc0876503410b2b966c124abc2311984ce2 # v2.3.9
-        with:
-          mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ${{ vars.AWS_EC2_AMI }}
-          ec2-instance-type: ${{ env.ec2_runner_variant }}
-          subnet-id: subnet-024298cefa3bedd61
-          security-group-id: sg-06300447c4a5fbef3
-          iam-role-name: instructlab-ci-runner
-          aws-resource-tags: >
-            [
-            {"Key": "Name", "Value": "instructlab-ci-github-unittest-runner"},
-            {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
-            {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
-            {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
-            ]
-
   run-unit-tests:
-    needs:
-      - start-ec2-runner
-    runs-on: ${{needs.start-ec2-runner.outputs.label}}
+    runs-on: ubuntu-latest
     # It is important that this job has no write permissions and has
     # no access to any secrets. This part is where we are running
     # untrusted code from PRs.
@@ -95,10 +55,10 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: "Install packages"
-        run: |
-          cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+      - name: Setup Python 3.11
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: 3.11
 
       - name: "Checkout code"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -125,30 +85,3 @@ jobs:
       - name: "Show disk utilization AFTER tests"
         run: |
           df -h
-
-  stop-ec2-runner:
-    needs:
-      - start-ec2-runner
-      - run-unit-tests
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    steps:
-      - name: "Harden runner"
-        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.10.1
-        with:
-          egress-policy: audit
-
-      - name: "Configure AWS credentials"
-        uses: "aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722" # v4.1.0
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: "Stop EC2 runner"
-        uses: machulav/ec2-github-runner@a8c20fc0876503410b2b966c124abc2311984ce2 # v2.3.9
-        with:
-          mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          label: ${{ needs.start-ec2-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-ec2-runner.outputs.ec2-instance-id }}


### PR DESCRIPTION
Unit tests are cheap and supposed to be quick and not require any
particular hardware.
