### PR TITLE
Fix FSDP mixed precision setting and loss w/ accelerate

### DIFF
--- a/src/instructlab/training/config.py
+++ b/src/instructlab/training/config.py
@@ -138,7 +138,7 @@ class FSDPOptions(BaseModel):
     """
 
     cpu_offload_params: Optional[bool] = False
-    sharding_strategy: ShardingStrategies = ShardingStrategies.SHARD_GRAD_OP
+    sharding_strategy: ShardingStrategies = ShardingStrategies.HYBRID_SHARD
 
 
 # public API

--- a/src/instructlab/training/setup_accelerator.py
+++ b/src/instructlab/training/setup_accelerator.py
@@ -76,11 +76,6 @@ def get_fsdp_config(args, model: PreTrainedModel):
     fsdp_plugin = FullyShardedDataParallelPlugin(
         auto_wrap_policy=wrap_policy,
         limit_all_gathers=True,
-        mixed_precision_policy=MixedPrecision(
-            param_dtype=torch.bfloat16,
-            reduce_dtype=torch.bfloat16,
-            buffer_dtype=torch.bfloat16,
-        ),
         backward_prefetch=prefetch_policy,
         sharding_strategy=ShardingStrategy[args.fsdp_sharding_strategy],
         cpu_offload=CPUOffload(args.cpu_offload_params_fsdp),
@@ -127,6 +122,7 @@ def setup_accelerator(args, model: PreTrainedModel, grad_accum):
     elif args.distributed_training_framework == "fsdp":
         accel_args = {
             "fsdp_plugin": get_fsdp_config(args, model),
+            "mixed_precision": "bf16",
         }
     else:
         raise ValueError(

--- a/src/instructlab/training/setup_accelerator.py
+++ b/src/instructlab/training/setup_accelerator.py
@@ -4,7 +4,7 @@ from functools import partial
 # Third Party
 from accelerate import Accelerator
 from peft.utils.other import fsdp_auto_wrap_policy
-from torch.distributed.fsdp import BackwardPrefetch, MixedPrecision, ShardingStrategy
+from torch.distributed.fsdp import BackwardPrefetch, ShardingStrategy
 from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 from transformers import PreTrainedModel
 import torch


### PR DESCRIPTION
Accelerate requires mixed_precision to be passed directly in config, else the fp32 upcast gets skipped and training loses overall precision, resulting in notably worse performance. Passing this also makes our manual mixed precision policy redundant, and since we are now _actually_ using mixed precision, hybrid shard finally becomes the new default sharding strategy to keep memory expectations in parity.