### PR TITLE
chore: Don't install pytest dependencies for coverage reports

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,6 @@ wheel_build_env = pkg
 deps =
     pytest
     pytest-asyncio
-    pytest-cov
-    pytest-html
 
 [testenv:py3]
 basepython = python3.11
@@ -24,8 +22,6 @@ passenv =
 deps = 
     pytest
     pytest-asyncio
-    pytest-cov
-    pytest-html
     -r requirements-dev.txt
 commands = {envpython} -m pytest tests/unit {posargs}
 # NOTE: {posargs} is a placeholder for input positional arguments


### PR DESCRIPTION
AFAIU we are not using them atm. We can return them if they are used in
CI.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
