### PR TITLE
chore: Require python3.11+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "InstructLab", email = "dev@instructlab.ai" }]
 description = "Training Library"
 readme = "README.md"
 license = { text = "Apache-2.0" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",
@@ -20,7 +20,6 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
@@ -53,7 +52,7 @@ where = ["src"]
 include = ["instructlab.training"]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 # same as black's default line length
 line-length = 88
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,7 @@ datasets>=2.15.0
 numba
 # Note: numpy ranges copied from instructlab/instructlab
 #
-# HabanaLabs / Intel Gaudi env comes with Python 3.10 and slightly older
-# versions of some dependencies. Use '3.10' as an indicator.
-# Habana installer has NumPy 1.23.5
-numpy>=1.23.5,<2.0.0 ; python_version == '3.10'
-numpy>=1.26.4,<2.0.0 ; python_version != '3.10'
+numpy>=1.26.4,<2.0.0
 rich
 instructlab-dolomite>=0.2.0
 trl>=0.9.4


### PR DESCRIPTION
We are not testing on older versions, and there's not a lot of reasons
to do so anyway. I believe for RHEL AI, we care about Python 3.11+ only.

For reference, https://devguide.python.org/versions/

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
