### PR TITLE
ci: Use pull_request as trigger for unit tests

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -9,7 +9,7 @@ on:
       - main
       - release-*
   # only run on PRs that touch certain regex paths
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - release-*


### PR DESCRIPTION
Otherwise the tested fork with the PR on review is not validated in CI.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
