### PR TITLE
ci: Install torch before flash-attn

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -113,6 +113,16 @@ jobs:
           . venv/bin/activate
           pip install tox
 
+      # flash-attn has a bug in the setup.py that causes pip to attempt
+      # installing it before torch is installed. This is a bug because their
+      # setup.py depends on importing the module, so it should have been listed
+      # in build_requires. Alas.
+      # See: https://github.com/Dao-AILab/flash-attention/pull/958
+      - name: "Install torch before other dependencies"
+        run: |
+          source venv/bin/activate
+          pip install torch
+
       - name: "Show disk utilization BEFORE tests"
         run: |
           df -h


### PR DESCRIPTION
This is to work around an issue in flash-attn build definition. The
issue manifests itself as:

```
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-u40hct41/flash-attn_36e9333b3570426a854895a477ce846d/setup.py", line 22, in <module>
          import torch
      ModuleNotFoundError: No module named 'torch'
      [end of output]
```

See: https://github.com/Dao-AILab/flash-attention/pull/958

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
