### PR TITLE
chore: Don't set ec2_runner_variant for unit tests

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -32,9 +32,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  ec2_runner_variant: "m7i.xlarge" # 4 Xeon CPU, 16GB RAM
-
 jobs:
   run-unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We no longer run these tests on EC2.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
