### PR TITLE
fixes non-granite model instantiation with Liger Kernel

### DIFF
--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -155,7 +155,13 @@ def setup_model(
             raise ValueError(
                 "Liger kernels are not installed. Please install Liger kernels using the following command: pip install liger-kernel"
             ) from e
-        model = AutoLigerKernelForCausalLM.from_pretrained(**base_model_args)
+
+        # NOTE: (jkunstle) we disable fused_linear_cross_entropy, even though it's a default for most of the models with LK support,
+        #   because reduce_sum_loss requires the logits, and fused_linear_cross_entropy explicitly skips materializing them for
+        #   performance.
+        model = AutoLigerKernelForCausalLM.from_pretrained(
+            **base_model_args, cross_entropy=True, fused_linear_cross_entropy=False
+        )
     else:
         model = AutoModelForCausalLM.from_pretrained(**base_model_args)
 


### PR DESCRIPTION
We change the model forward method to use a different loss function. Liger Kernel's `FusedLinearCrossEntropy` kernel doesn't materialize these logits, so our custom forward was broken for Qwen2.5, Llama3, Gemma3, etc.

This switches `FusedLinearCrossEntropy` for `FusedCrossEntropy` as the default kernel used.