### PR TITLE
chore: Allow numpy >= 2.0.0

### DIFF
--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -109,7 +109,7 @@ nodeenv==1.9.1            # via pre-commit
 notebook==7.4.3           # via jupyter
 notebook-shim==0.2.4      # via jupyterlab, notebook
 numba==0.61.2             # via -r requirements.txt
-numpy==1.26.4             # via accelerate, bitsandbytes, contourpy, datasets, deepspeed, matplotlib, numba, pandas, peft, tensorboard, transformers, -r requirements-dev.txt, -r requirements.txt
+numpy==2.2.6              # via accelerate, bitsandbytes, contourpy, datasets, deepspeed, matplotlib, numba, pandas, peft, tensorboard, transformers, -r requirements-dev.txt, -r requirements.txt
 nvidia-cublas-cu12==12.4.5.8  # via nvidia-cudnn-cu12, nvidia-cusolver-cu12, torch
 nvidia-cuda-cupti-cu12==12.4.127  # via torch
 nvidia-cuda-nvrtc-cu12==12.4.127  # via torch

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@
 
 isort
 matplotlib
-numpy
 pre-commit>=3.0.4
 pylint>=2.16.2
 pylint-pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ transformers>=4.45.2
 
 datasets>=2.15.0
 numba
-numpy>=1.26.4,<2.0.0
+numpy>=1.26.4
 rich
 instructlab-dolomite>=0.2.0
 trl>=0.9.4


### PR DESCRIPTION
A large e2e run with forced numpy 2.0+ suggests that the library is compatible with numpy 2.x series.

Also, removed `numpy` dependency from requirements-dev.txt because it's already listed in requirements.txt.

See: https://github.com/instructlab/training/actions/runs/14539292904

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
