### PR TITLE
ci: Use tox-current-env to reuse prepared venv with torch

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -143,10 +143,23 @@ jobs:
       # setup.py depends on importing the module, so it should have been listed
       # in build_requires. Alas.
       # See: https://github.com/Dao-AILab/flash-attention/pull/958
-      - name: "Install torch before other dependencies"
+      - name: "Install torch and other unlisted build dependencies for flash-attn"
         run: |
           source venv/bin/activate
-          pip install torch
+          # The list is taken from the pull request linked above
+          pip install torch packaging setuptools wheel psutil ninja
+
+      - name: "Install tox-current-env to reuse the venv with pre-installed build dependencies"
+        run: |
+          source venv/bin/activate
+          pip install tox-current-env
+
+      - name: "Install dependencies from tox.ini in the current venv, using current venv installed deps"
+        run: |
+          source venv/bin/activate
+          tox -e py3-smoke --print-deps-to-file=./deps.txt
+          pip install -r ./deps.txt --no-build-isolation
+          pip install .
 
       - name: "Show disk utilization BEFORE tests"
         run: |
@@ -155,7 +168,7 @@ jobs:
       - name: "Run smoke tests with Tox and Pytest"
         run: |
           source venv/bin/activate
-          tox -e py3-smoke
+          tox --current-env -e py3-smoke
 
       - name: "Show disk utilization AFTER tests"
         run: |


### PR DESCRIPTION
This is a completion of a workaround for flash-attn. The initial attempt didn't work because we still used tox to run smoke tests, which means another venv was created that did not include flash-attn.

To achieve sharing the venv for both torch installation and smoke tests, we are using tox-current-env plugin here.