### PR TITLE
Obey the FSDP sharding option default

### DIFF
--- a/src/instructlab/training/config.py
+++ b/src/instructlab/training/config.py
@@ -195,7 +195,7 @@ class TrainingArgs(BaseModel):
     )
     fsdp_options: FSDPOptions = Field(
         default_factory=lambda: FSDPOptions(
-            cpu_offload_params=False, sharding_strategy=ShardingStrategies.SHARD_GRAD_OP
+            cpu_offload_params=False,
         )
     )
     distributed_backend: DistributedBackend = DistributedBackend.FSDP


### PR DESCRIPTION
Our default FSDPOptions object in training config was overriding the default we set in the FSDPOptions object definition.