### PR TITLE
fix(deps): Re-install flash-attn with '--no-build-isolation' to temporarily unblock CI

### DIFF
--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -191,6 +191,14 @@ jobs:
           # install with Torch and build dependencies installed
           python3.11 -m pip install packaging wheel setuptools-scm
           python3.11 -m pip install .[cuda] -r requirements-vllm-cuda.txt
+          # Below is a temporary solution to unblock this job. See issue:
+          # https://github.com/instructlab/training/issues/494
+          # <---- START TEMPORARY SOLUTION --->
+          python3.11 -m pip uninstall -y flash-attn
+          python3.11 -m pip cache purge
+          python3.11 -m pip install ninja
+          MAX_JOBS=8 python3.11 -m pip install flash-attn --no-build-isolation
+          # <---- END TEMPORARY SOLUTION --->
 
       - name: Update instructlab-training library
         working-directory: ./training


### PR DESCRIPTION
There appears to be an error related to `flash-attn`. More info here: https://github.com/instructlab/training/issues/494

This PR is a temporary solution to unblock the large E2E job.