### PR TITLE
use instructlab `constraints-dev.txt` in e2e test

### DIFF
--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -185,7 +185,7 @@ jobs:
           nvidia-smi
           python3.11 -m pip cache remove llama_cpp_python
 
-          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install .
+          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install . -c constraints-dev.txt
 
           # https://github.com/instructlab/instructlab/issues/1821
           # install with Torch and build dependencies installed


### PR DESCRIPTION
For instructlab, `pip install .` does not install `vllm`, but it does install an uncapped `torch` (`2.7.0` currently).

When we install `vllm` later, we compile a binary `flash_attn` wheel against `torch-2.7.0`. `vllm-0.8.4` requires `torch==2.6.0`, so we downgrade `torch`, and then we use that with the incompatible `flash_attn` binary wheel.

To resolve this, use instructlab's `constraints-dev.txt` in the first `pip install` operation. This restricts `torch` to `2.6.0` immediately when we first install instructlab, so that we will compile `flash_attn` against that `torch` version.

Fixes: #494 