### PR TITLE
fix: extend nccl timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,3 +370,9 @@ run_training(
     train_args=training_args,
 )
 ```
+
+## Environment variables
+
+Below is a list of custom environment variables users can set in the training library.
+
+1. `INSTRUCTLAB_NCCL_TIMEOUT_MS`, this environment variable controls the NCCL timeout in milliseconds. Consider increasing if seeing FSDP related NCCL errors.

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ basepython = python3.11
 description = run unit tests with pytest
 passenv =
 	HF_HOME
+        INSTRUCTLAB_NCCL_TIMEOUT_MS
 deps = 
     pytest
     -r requirements-dev.txt
@@ -31,6 +32,7 @@ commands = {envpython} -m pytest tests/unit {posargs}
 description = run accelerated smoke tests with pytest
 passenv =
 	HF_HOME
+        INSTRUCTLAB_NCCL_TIMEOUT_MS
 deps = 
     pytest
     -r requirements-dev.txt


### PR DESCRIPTION
extend nccl timeout to combat CI timeouts w/ FSDP optimizer state saving 