### PR TITLE
deps: Remove caps on ROCm dependencies

### DIFF
--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -1,3 +1,3 @@
-flash-attn>=2.6.2,<2.7.0
+flash-attn>=2.6.2
 # required for FSDP updates
-accelerate>=0.34.2,<1.1.0
+accelerate>=0.34.2


### PR DESCRIPTION
## Overview

We don't need to cap these dependencies at this time. If we do, we should cap them in a `constraints-dev.txt` file like we do in the core repo, but we don't actually need a constraints file if we're not testing upstream.