### PR TITLE
ci: don't trigger pull_request_target job on its own workflow

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -23,7 +23,6 @@ on:
       - "pyproject.toml"
       - "requirements-dev.txt"
       - "requirements-cuda.txt"
-      - ".github/workflows/smoke.yaml" # This workflow
 
 permissions:
   contents: read


### PR DESCRIPTION
pull_request_target means that the workflow will be pulled from main,
not from the PR under review; so it's a waste to run the workflow in
this case.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
