### PR TITLE
 add and document building flash-attn with ninja

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Install the library:
 pip install instructlab-training 
 ```
 
-You can then install the library for development:
+You can also install the library for development:
 
 ```bash
 pip install -e ./training
@@ -47,19 +47,28 @@ pip install -e ./training
 ### Additional NVIDIA packages
 
 This library uses the `flash-attn` package as well as other packages, which rely on NVIDIA-specific CUDA tooling to be installed.
-If you are using NVIDIA hardware with CUDA, you need to install the following additional dependencies.
+If you are using NVIDIA hardware with CUDA, you need to install the `cuda` extra dependencies.
 
-Basic install
+Basic install:
 
 ```bash
 pip install .[cuda]
 ```
 
-Editable install (development)
+Editable install for development:
 
 ```bash
-pip install -e .[cuda]
+pip install -e ".[cuda]"
 ```
+
+When installing `flash-attn` it is recommended to enable high build parallelism. The `ninja` build system will be installed with the
+standard requirements. Parallelism is configurable with the environment variable `MAX_JOBS`. 
+On an AWS `g6.16xlarge` system, a reasonable build command would be:
+
+```bash
+MAX_JOBS=24 pip install -e ".[cuda]"
+```
+
 
 ## Using the library
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,6 @@ trl>=0.9.4
 peft
 pydantic>=2.7.0
 aiofiles>=23.2.1
+
+# nice to have in case we build flash-attn
+ninja


### PR DESCRIPTION
building flash-attn wheel was taking >2hr without ninja and higher parallelism. this change adds ninja as a default requirement for the package (because it needs to be installed _for_ flash-attn and is tiny).

this change also adds a short note about setting build parallelism with the `MAX_JOBS` environment variable to configure the ninja build for flash-attn