### PR TITLE
docs: Remove badge for a no longer existing job

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 ![Release](https://img.shields.io/github/v/release/instructlab/training)
 ![License](https://img.shields.io/github/license/instructlab/training)
 
-![`e2e-nvidia-l4-x1.yml` on `main`](https://github.com/instructlab/training/actions/workflows/e2e-nvidia-l4-x1.yml/badge.svg?branch=main)
 ![`e2e-nvidia-l40s-x4.yml` on `main`](https://github.com/instructlab/training/actions/workflows/e2e-nvidia-l40s-x4.yml/badge.svg?branch=main)
 
 ## About the Library


### PR DESCRIPTION
It was removed in 5d510fbca8b9be26c3cfee6dcf6b7f398a0d78cb.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
