### PR TITLE
uses `__name__` in logging.getLogger

### DIFF
--- a/src/instructlab/training/data_process.py
+++ b/src/instructlab/training/data_process.py
@@ -27,7 +27,7 @@ MASK_TOKEN = "<|MASK|>"
 UNMASK_BEGIN_TOKEN = "<|UNMASK_BEGIN|>"
 UNMASK_END_TOKEN = "<|UNMASK_END|>"
 
-logger = logging.getLogger("instructlab.training")
+logger = logging.getLogger(__name__)
 
 
 def check_valid_sample(

--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -90,7 +90,7 @@ from instructlab.training.utils import (
 )
 import instructlab.training.data_process as dp
 
-logger = logging.getLogger("instructlab.training")
+logger = logging.getLogger(__name__)
 
 
 def setup_optimizer(args, model):


### PR DESCRIPTION
previously, was using a string-literal for the logger name, e.g. `instructlab.training`

This is a small add-on PR to @RobotSail 's recent add, #571 