### PR TITLE
ci: stop reporting results to slack

### DIFF
--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -262,34 +262,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Post job results to Slack if the workflow failed
-        if: failure() && steps.check_pr.outputs.is_pr == 'false'
-        id: slack-report-failure
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          token: ${{ secrets.SON_OF_JEEVES_TOKEN }}
-          method: chat.postMessage
-          payload: |
-            # Slack channel id, channel name, or user id to post message.
-            # See also: https://api.slack.com/methods/chat.postMessage#channels
-            # You can pass in multiple channels to post to by providing a comma-delimited list of channel IDs.
-            channel: 'e2e-ci-results'
-            text: "*e2e-nvidia-l40s-x4* job in *${{ github.repository }}* running on branch `${{ steps.check_pr.outputs.pr_or_branch }}` completed *with failures* :meow_sad-rain: | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
-      - name: Post job results to Slack if the workflow succeeded
-        if: success() && steps.check_pr.outputs.is_pr == 'false'
-        id: slack-report-success
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          token: ${{ secrets.SON_OF_JEEVES_TOKEN }}
-          method: chat.postMessage
-          payload: |
-            # Slack channel id, channel name, or user id to post message.
-            # See also: https://api.slack.com/methods/chat.postMessage#channels
-            # You can pass in multiple channels to post to by providing a comma-delimited list of channel IDs.
-            channel: 'e2e-ci-results'
-            text: "*e2e-nvidia-l40s-x4* job in *${{ github.repository }}* running on branch `${{ steps.check_pr.outputs.pr_or_branch }}` completed *successfully* :meow_party: | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
       - name: Send Discord notification for failure
         if: failure() && steps.check_pr.outputs.is_pr == 'false'
         uses: sarisia/actions-status-discord@5ddd3b114a98457dd80a39b2f00b6a998cd69008 # v1.15.3

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -31,15 +31,14 @@ For more details about the E2E scripts themselves, see [the InstructLab Core doc
 
 ### Current E2E Jobs
 
-| Name | T-Shirt Size | Runner Host | Instance Type | OS | GPU Type | Script | Flags | Runs when? | Slack/Discord reporting? |
+| Name | T-Shirt Size | Runner Host | Instance Type | OS | GPU Type | Script | Flags | Runs when? | Discord reporting? |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | [`e2e-nvidia-l40s-x4.yml`](https://github.com/instructlab/training/blob/main/.github/workflows/e2e-nvidia-l40s-x4.yml) | Large | AWS |[`g6e.12xlarge`](https://aws.amazon.com/ec2/instance-types/g6e/) | CentOS Stream 9 | 4 x NVIDIA L40S w/ 48 GB VRAM (192 GB) | `e2e-ci.sh` | `l` | Manually by Maintainers, Automatically against `main` branch at 4PM UTC | Yes |
 
-### Discord/Slack reporting
+### Discord reporting
 
-Some E2E jobs send their results to the channel `#e2e-ci-results` via the `Son of Jeeves` bot in both Discord and Slack. You can see which jobs currently have reporting via the "Current E2E Jobs" table above.
+Some E2E jobs send their results to the channel `#e2e-ci-results` via the `Son of Jeeves` bot in Discord. You can see which jobs currently have reporting via the "Current E2E Jobs" table above.
 
-In Slack, this has been implemented via [the official Slack GitHub Action](https://github.com/slackapi/slack-github-action?tab=readme-ov-file#technique-2-slack-app).
 In Discord, we use [actions/actions-status-discord](https://github.com/sarisia/actions-status-discord) and the built-in channel webhooks feature.
 
 ### Triggering an E2E job via GitHub Web UI


### PR DESCRIPTION
Stop reporting CI results to Slack. This simplifies our e2e job definitions and removes a dependency on Slack. Most developers have moved to Discord.

Related: instructlab/instructlab#3441