### PR TITLE
use LigerCrossEntropy loss with reduction=sum

### DIFF
--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -55,6 +55,7 @@ from transformers import (
 )
 import torch
 import torch.distributed
+from torch.nn import CrossEntropyLoss
 
 # First Party
 from instructlab.training import config
@@ -145,7 +146,6 @@ def setup_model(
         base_model_args["attn_implementation"] = "flash_attention_2"
 
     if args.use_dolomite:
-        from torch.nn import CrossEntropyLoss
         with ensure_loadable_dolomite_checkpoint(
             args.model_name_or_path, args.output_dir
         ) as path:

--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -17,7 +17,6 @@ import warnings
 # Third Party
 from accelerate import Accelerator
 
-
 try:
     # Third Party
     from deepspeed.ops.adam import DeepSpeedCPUAdam

--- a/src/instructlab/training/utils.py
+++ b/src/instructlab/training/utils.py
@@ -425,8 +425,7 @@ def convert_loss_to_reduce_sum(model, use_dolomite=False):
                 shift_labels = shift_labels.view(-1)
                 # Ensure tensors are on the same device
                 shift_labels = shift_labels.to(shift_logits.device)
-                loss_fct = torch.nn.CrossEntropyLoss(reduction="sum")
-                loss = loss_fct(shift_logits, shift_labels)
+                loss = model.loss_fct(shift_logits, shift_labels)
 
             if not return_dict:
                 return ((loss,) + output) if loss is not None else output


### PR DESCRIPTION
Currently, we are using `torch.nn.CrossEntropyLoss(reduction=sum)` with LK to facilitate multipack sampling, which leads to some weird behaviours as reported [here](https://issues.redhat.com/browse/RHELAI-4113). This PR enables us to use `LigerCrossEntropyLoss` with the multi-pack sampler, and solves the incorrect loss issue. 