### PR TITLE
fixes unit tests requiring cuda

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,14 @@ basepython = python3.11
 description = run unit tests with pytest
 passenv =
 	HF_HOME
-        INSTRUCTLAB_NCCL_TIMEOUT_MS
+	INSTRUCTLAB_NCCL_TIMEOUT_MS
+	CMAKE_ARGS
+
+# Use PyTorch CPU build instead of CUDA build in test envs. CUDA dependencies
+# are huge. This reduces venv from 5.7 GB to 1.5 GB.
+setenv =
+    PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
+    CMAKE_ARGS={env:CMAKE_ARGS:-DGGML_NATIVE=off}
 deps = 
     pytest
     wandb


### PR DESCRIPTION
unit tests were breaking because Torch couldn't import the cuda toolkit. This isn't desirable because even on cuda systems unit tests shouldn't be written the require cuda. This coudl be changed in the future though.