### PR TITLE
ci: Disable dependabot for pip dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,3 @@ updates:
     directory: "/.github/workflows"
     schedule:
       interval: "daily"
-
-  # Maintain dependencies for Python scripts
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
