### PR TITLE
ci: do not require DCO job

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,7 +11,6 @@ pull_request_rules:
     - label!=hold
     - label!=do-not-merge
     - label!=needs-rebase
-    - check-success=DCO
 
     # The files conditions regex should match the globs in workflow files
     # If workflow configuration files in .github/ are changed, the actionlint check must pass


### PR DESCRIPTION
We are going to disable this job for this repository and rely on contributors' implicit acceptance of `DCO.txt` instead.

Related: instructlab/dev-docs#192