### PR TITLE
adds build step for flash-attn to tox py3-smoke env

### DIFF
--- a/.github/actions/run-smoke/action.yml
+++ b/.github/actions/run-smoke/action.yml
@@ -31,33 +31,6 @@ runs:
         . venv/bin/activate
         pip install tox -c constraints-dev.txt
 
-    # flash-attn has a bug in the setup.py that causes pip to attempt
-    # installing it before torch is installed. This is a bug because their
-    # setup.py depends on importing the module, so it should have been listed
-    # in build_requires. Alas. See:
-    # https://github.com/Dao-AILab/flash-attention/pull/958
-    - name: "Install torch and other unlisted build dependencies for flash-attn"
-      shell: bash
-      run: |
-        source venv/bin/activate
-        # The list is taken from the pull request linked above
-        pip install torch packaging setuptools wheel psutil ninja -c constraints-dev.txt
-
-    - name: "Install tox-current-env to reuse the venv with pre-installed build dependencies"
-      shell: bash
-      run: |
-        source venv/bin/activate
-        pip install tox-current-env
-
-    - name: "Install dependencies from tox.ini in the current venv, using current venv installed deps"
-      shell: bash
-      run: |
-        source venv/bin/activate
-        tox -e py3-smoke --print-deps-to-file=./deps.txt
-        pip_install="pip install -c constraints-dev.txt"
-        $pip_install -r ./deps.txt --no-build-isolation
-        $pip_install .
-
     - name: "Show disk utilization BEFORE tests"
       shell: bash
       if: always()
@@ -68,7 +41,7 @@ runs:
       shell: bash
       run: |
         source venv/bin/activate
-        tox --current-env -e py3-smoke
+        tox -e py3-smoke
 
     - name: "Show disk utilization AFTER tests"
       shell: bash

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,6 @@ pylint-pydantic
 pytest
 ruff
 tox>=4.4.2
-tox-current-env
 
 mypy>=1.10.0
 types-tqdm
@@ -25,3 +24,4 @@ huggingface_hub
 
 wandb
 tensorboard
+ninja

--- a/scripts/install_flash_attn_if_needed.py
+++ b/scripts/install_flash_attn_if_needed.py
@@ -1,0 +1,27 @@
+# Standard
+import importlib.util
+import subprocess
+import sys
+
+
+def flash_attn_is_installed() -> bool:
+    return importlib.util.find_spec("flash_attn") is not None
+
+
+if flash_attn_is_installed():
+    print("flash-attn already installed, skipping.")
+else:
+    print("flash-attn not found in environment, installing...")
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-r",
+            "requirements-cuda.txt",
+            "-c",
+            "constraints-dev.txt",
+            "--no-build-isolation",
+        ]
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ wheel_build_env = pkg
 deps =
     pytest
 install_command = pip install \
-                  -c constraints-dev.txt \
-                  {opts} {packages}
+    -c constraints-dev.txt \
+    {opts} {packages}
 
 [testenv:py3]
 basepython = python3.11
@@ -40,11 +40,15 @@ commands = {envpython} -m pytest tests/unit {posargs}
 [testenv:py3-smoke]
 description = run accelerated smoke tests with pytest
 passenv =
-	HF_HOME
-        INSTRUCTLAB_NCCL_TIMEOUT_MS
+    HF_HOME
+    INSTRUCTLAB_NCCL_TIMEOUT_MS
+# ninja and 'commands_pre' step required to build flash-attn
+# `install_flash_attn_if_needed` runs every time we run the `commands`
+# section but exits immediately if flash-attn is already installed
 deps = 
     -r requirements-dev.txt
-    -r requirements-cuda.txt
+commands_pre =
+    python3 scripts/install_flash_attn_if_needed.py
 commands = {envpython} -m pytest tests/smoke {posargs}
 
 # format, check, and linting targets don't build and install the project to


### PR DESCRIPTION
flash-attn can't be built inline with other dependencies because it requires torch and ninja. we're currently getting around this with a `tox_current_env` setup but that's tricky from a tox perspective. this change makes it so that we can use tox to build the environment directly, and that the environment won't be rebuilt in between command runs.

Closes: #548
Closes: #592