### PR TITLE
ci: Uncap torch, allowing it to bump to 2.7.1 in constraints

### DIFF
--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -17,7 +17,7 @@ babel==2.17.0             # via jupyterlab-server
 beautifulsoup4==4.13.4    # via nbconvert
 bitsandbytes==0.46.0      # via -r requirements-cuda.txt
 bleach==6.2.0             # via nbconvert
-cachetools==6.0.0         # via tox
+cachetools==6.1.0         # via tox
 certifi==2025.6.15        # via httpcore, httpx, requests, sentry-sdk
 cffi==1.17.1              # via argon2-cffi-bindings
 cfgv==3.4.0               # via pre-commit
@@ -39,7 +39,7 @@ einops==0.8.1             # via deepspeed, flash-attn
 executing==2.2.0          # via stack-data
 fastjsonschema==2.21.1    # via nbformat
 filelock==3.18.0          # via datasets, huggingface-hub, torch, tox, transformers, virtualenv
-flash-attn==2.7.4.post1   # via -r requirements-cuda.txt, -r requirements-rocm.txt
+flash-attn==2.8.0.post2   # via -r requirements-cuda.txt, -r requirements-rocm.txt
 fonttools==4.58.4         # via matplotlib
 fqdn==1.5.1               # via jsonschema
 frozenlist==1.7.0         # via aiohttp, aiosignal
@@ -48,7 +48,7 @@ gitdb==4.0.12             # via gitpython
 gitpython==3.1.44         # via wandb
 grpcio==1.73.0            # via tensorboard
 h11==0.16.0               # via httpcore
-hf-xet==1.1.3             # via huggingface-hub
+hf-xet==1.1.4             # via huggingface-hub
 hjson==3.1.0              # via deepspeed
 httpcore==1.0.9           # via httpx
 httpx==0.28.1             # via jupyterlab
@@ -94,9 +94,9 @@ mdurl==0.1.2              # via markdown-it-py
 mistune==3.1.3            # via nbconvert
 mpmath==1.3.0             # via sympy
 msgpack==1.1.1            # via deepspeed
-multidict==6.4.4          # via aiohttp, yarl
+multidict==6.5.0          # via aiohttp, yarl
 multiprocess==0.70.16     # via datasets
-mypy==1.16.0              # via -r requirements-dev.txt
+mypy==1.16.1              # via -r requirements-dev.txt
 mypy-extensions==1.1.0    # via mypy
 nbclient==0.10.2          # via nbconvert
 nbconvert==7.16.6         # via jupyter, jupyter-server
@@ -109,19 +109,20 @@ notebook==7.4.3           # via jupyter
 notebook-shim==0.2.4      # via jupyterlab, notebook
 numba==0.61.2             # via -r requirements.txt
 numpy==1.26.4             # via accelerate, bitsandbytes, contourpy, datasets, deepspeed, matplotlib, numba, pandas, peft, tensorboard, transformers, -r requirements-dev.txt, -r requirements.txt
-nvidia-cublas-cu12==12.4.5.8  # via nvidia-cudnn-cu12, nvidia-cusolver-cu12, torch
-nvidia-cuda-cupti-cu12==12.4.127  # via torch
-nvidia-cuda-nvrtc-cu12==12.4.127  # via torch
-nvidia-cuda-runtime-cu12==12.4.127  # via torch
-nvidia-cudnn-cu12==9.1.0.70  # via torch
-nvidia-cufft-cu12==11.2.1.3  # via torch
-nvidia-curand-cu12==10.3.5.147  # via torch
-nvidia-cusolver-cu12==11.6.1.9  # via torch
-nvidia-cusparse-cu12==12.3.1.170  # via nvidia-cusolver-cu12, torch
-nvidia-cusparselt-cu12==0.6.2  # via torch
-nvidia-nccl-cu12==2.21.5  # via torch
-nvidia-nvjitlink-cu12==12.4.127  # via nvidia-cusolver-cu12, nvidia-cusparse-cu12, torch
-nvidia-nvtx-cu12==12.4.127  # via torch
+nvidia-cublas-cu12==12.6.4.1  # via nvidia-cudnn-cu12, nvidia-cusolver-cu12, torch
+nvidia-cuda-cupti-cu12==12.6.80  # via torch
+nvidia-cuda-nvrtc-cu12==12.6.77  # via torch
+nvidia-cuda-runtime-cu12==12.6.77  # via torch
+nvidia-cudnn-cu12==9.5.1.17  # via torch
+nvidia-cufft-cu12==11.3.0.4  # via torch
+nvidia-cufile-cu12==1.11.1.6  # via torch
+nvidia-curand-cu12==10.3.7.77  # via torch
+nvidia-cusolver-cu12==11.7.1.2  # via torch
+nvidia-cusparse-cu12==12.5.4.2  # via nvidia-cusolver-cu12, torch
+nvidia-cusparselt-cu12==0.6.3  # via torch
+nvidia-nccl-cu12==2.26.2  # via torch
+nvidia-nvjitlink-cu12==12.6.85  # via nvidia-cufft-cu12, nvidia-cusolver-cu12, nvidia-cusparse-cu12, torch
+nvidia-nvtx-cu12==12.6.77  # via torch
 overrides==7.7.0          # via jupyter-server
 packaging==25.0           # via accelerate, datasets, deepspeed, huggingface-hub, ipykernel, jupyter-events, jupyter-server, jupyterlab, jupyterlab-server, matplotlib, nbconvert, peft, pyproject-api, pytest, tensorboard, tox, transformers, wandb, -r requirements.txt
 pandas==2.3.0             # via datasets
@@ -152,7 +153,7 @@ pylint-plugin-utils==0.8.2  # via pylint-pydantic
 pylint-pydantic==0.3.5    # via -r requirements-dev.txt
 pyparsing==3.2.3          # via matplotlib
 pyproject-api==1.9.1      # via tox
-pytest==8.4.0             # via -r requirements-dev.txt
+pytest==8.4.1             # via -r requirements-dev.txt
 python-dateutil==2.9.0.post0  # via arrow, jupyter-client, matplotlib, pandas
 python-json-logger==3.3.0  # via jupyter-events
 pytz==2025.2              # via pandas
@@ -165,32 +166,32 @@ rfc3339-validator==0.1.4  # via jsonschema, jupyter-events
 rfc3986-validator==0.1.1  # via jsonschema, jupyter-events
 rich==14.0.0              # via -r requirements.txt
 rpds-py==0.25.1           # via jsonschema, referencing
-ruff==0.11.13             # via -r requirements-dev.txt
+ruff==0.12.0              # via -r requirements-dev.txt
 safetensors==0.5.3        # via accelerate, instructlab-dolomite, peft, transformers
 send2trash==1.8.3         # via jupyter-server
 sentry-sdk==2.30.0        # via wandb
 setproctitle==1.3.6       # via wandb
-setuptools==80.9.0        # via jupyterlab, tensorboard
+setuptools==80.9.0        # via jupyterlab, tensorboard, triton
 six==1.17.0               # via python-dateutil, rfc3339-validator, tensorboard
 smmap==5.0.2              # via gitdb
 sniffio==1.3.1            # via anyio
 soupsieve==2.7            # via beautifulsoup4
 stack-data==0.6.3         # via ipython
-sympy==1.13.1             # via torch
+sympy==1.14.0             # via torch
 tensorboard==2.19.0       # via -r requirements-dev.txt
 tensorboard-data-server==0.7.2  # via tensorboard
 terminado==0.18.1         # via jupyter-server, jupyter-server-terminals
 tinycss2==1.4.0           # via bleach
 tokenizers==0.21.1        # via transformers
 tomlkit==0.13.3           # via pylint
-torch==2.6.0              # via accelerate, bitsandbytes, deepspeed, flash-attn, instructlab-dolomite, liger-kernel, peft, -c constraints-dev.txt.in, -r requirements.txt
+torch==2.7.1              # via accelerate, bitsandbytes, deepspeed, flash-attn, instructlab-dolomite, liger-kernel, peft, -r requirements.txt
 tornado==6.5.1            # via ipykernel, jupyter-client, jupyter-server, jupyterlab, notebook, terminado
-tox==4.26.0               # via tox-current-env, -r requirements-dev.txt
+tox==4.27.0               # via tox-current-env, -r requirements-dev.txt
 tox-current-env==0.0.16   # via -r requirements-dev.txt
 tqdm==4.67.1              # via datasets, deepspeed, huggingface-hub, peft, transformers
 traitlets==5.14.3         # via comm, ipykernel, ipython, ipywidgets, jupyter-client, jupyter-console, jupyter-core, jupyter-events, jupyter-server, jupyterlab, matplotlib-inline, nbclient, nbconvert, nbformat
 transformers==4.52.4      # via instructlab-dolomite, peft, trl, -r requirements.txt
-triton==3.2.0             # via liger-kernel, torch
+triton==3.3.1             # via liger-kernel, torch
 trl==0.18.2               # via -r requirements.txt
 types-python-dateutil==2.9.0.20250516  # via arrow
 types-pyyaml==6.0.12.20250516  # via -r requirements-dev.txt

--- a/constraints-dev.txt.in
+++ b/constraints-dev.txt.in
@@ -1,10 +1,1 @@
 # SPDX-License-Identifier: Apache-2.0
-
-# These are synchronized with instructlab repo; we have to keep them in sync at
-# least until we no longer tie training repo CI with ilab repo through e2e jobs.
-torch<2.7.0
-vllm<0.9.0
-
-# flash-attn 2.8.0+ is broken for torch 2.6.x.
-# See: https://github.com/Dao-AILab/flash-attention/issues/1717
-flash-attn<2.8.0


### PR DESCRIPTION
This also brings newer CUDA into CI.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
