### PR TITLE
ci: Use torch CUDA 12.8 index when calculating constraints

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,9 @@ package = wheel
 wheel_build_env = pkg
 deps =
     pytest
+setenv =
+    PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu128
+    UV_INDEX=https://download.pytorch.org/whl/cu128
 install_command = pip install \
                   -c constraints-dev.txt \
                   {opts} {packages}


### PR DESCRIPTION
This should allows to bump to 12.8 (after torch is bumped past 2.6.0).

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
