### PR TITLE
fix edge case for qwen3 data processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ The library now supports an optional `reasoning_content` field in addition to th
 - Supporting models that need to generate internal reasoning traces
 - Enabling step-by-step reasoning in model responses
 
+> **Note**: this is only supported for models with chat templates that use the DeepSeek R1-style parser. Models without a custom thought processor such as Phi-4 must still provide their reasoning traces in the `content` field.
+
 **Example message structure with reasoning content:**
 
 ```json
@@ -137,7 +139,11 @@ The library now supports an optional `reasoning_content` field in addition to th
 }
 ```
 
-Both `content` and `reasoning_content` fields are processed during training according to the unmasking rules specified by the unmask_roles parameter. When a message role is included in unmask_roles, both fields (if present) will be unmasked for training.
+#### Important Notes
+
+1. **Automatic reasoning content processing**: If `reasoning_content` exists in a message, it will always be processed and unmasked as long as the message role is targeted for unmasking. This ensures that reasoning traces are properly included in the training data.
+
+2. **DeepSeek R1 Thinking Compatibility**: Models using the DeepSeek R1 thought processor (such as Qwen3) must supply their thinking traces in the `reasoning_content` field to be processed correctly. Failure to do so may result in improper handling of reasoning tokens and suboptimal training performance.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,18 @@ The InstructLab Training library is an optimized model instruction-tuning librar
 To simplify the process of fine-tuning models with the [LAB
 method](https://arxiv.org/abs/2403.01081), or for general use, this library provides a simple pythonic training interface.
 
+### Reasoning Content Support
+
+The library now supports reasoning traces through the `reasoning_content` field in message samples. This enables training models that can handle both regular content and structured reasoning traces, making it ideal for training reasoning-capable models that can separate their thinking process from their final output.
+
 ## Usage and Guidance Sections
 
 - [Installing](#installing-the-library)
   - [Additional Nvidia packages](#additional-nvidia-packages)
 - [Using the library](#using-the-library)
+- [Data format](#data-format)
+  - [Reasoning content support](#reasoning-content-support-1)
+- [Documentation](#documentation)
 - [Learning about the training arguments](#learning-about-training-arguments)
   - [`TrainingArgs`](#trainingargs)
   - [`DeepSpeedOptions`](#deepspeedoptions)
@@ -79,6 +86,66 @@ You can then define various training arguments. They will serve as the parameter
 
 - [Learning about the training argument](#learning-about-training-arguments)
 - [Example training run with arguments](#example-training-run-with-arguments)
+
+## Data format
+
+The library expects training data in the messages format, where each sample contains a list of messages with different roles (user, assistant, system, etc.). Each message should have at minimum:
+
+- `role`: The role of the message sender (e.g., "user", "assistant", "system")
+- `content`: The main content of the message
+
+### Reasoning content support
+
+The library now supports an optional `reasoning_content` field in addition to the standard `content` field. This enables training models with structured reasoning traces. The `reasoning_content` field is particularly useful for:
+
+- Training reasoning-capable models that can separate their thinking process from their output
+- Supporting models that need to generate internal reasoning traces
+- Enabling step-by-step reasoning in model responses
+
+**Example message structure with reasoning content:**
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is 15 * 23?"
+    },
+    {
+      "role": "assistant",
+      "reasoning_content": "I need to multiply 15 by 23. Let me break this down: 15 * 23 = 15 * (20 + 3) = 15 * 20 + 15 * 3 = 300 + 45 = 345",
+      "content": "15 * 23 = 345"
+    }
+  ]
+}
+```
+
+**Standard message structure:**
+
+```json
+{
+  "messages": [
+    {
+      "role": "user", 
+      "content": "Hello! How are you?"
+    },
+    {
+      "role": "assistant",
+      "content": "Hello! I'm doing well, thank you for asking. How can I help you today?"
+    }
+  ]
+}
+```
+
+Both `content` and `reasoning_content` fields are processed during training according to the unmasking rules specified by the unmask_roles parameter. When a message role is included in unmask_roles, both fields (if present) will be unmasked for training.
+
+## Documentation
+
+For detailed information about specific features:
+
+- **[Reasoning Content Support](docs/reasoning_content.md)**: Comprehensive guide to using the `reasoning_content` field for training reasoning-capable models
+- **[CI Documentation](docs/ci.md)**: Information about continuous integration processes
+- **[Logging Documentation](docs/logging.md)**: Guide to logging configuration and usage
 
 ## Learning about training arguments
 

--- a/docs/reasoning_content.md
+++ b/docs/reasoning_content.md
@@ -1,0 +1,181 @@
+# Reasoning Content Support
+
+The InstructLab Training library supports structured reasoning traces through the `reasoning_content` field in message samples. This feature enables training models that can separate their thinking process from their final output.
+
+## Overview
+
+The `reasoning_content` field is an optional addition to the standard message format that allows you to include the model's internal reasoning process alongside the final response. This is particularly useful for:
+
+- Training reasoning-capable models that show their work
+- Supporting models that need to generate step-by-step reasoning
+- Enabling chain-of-thought style training data
+- Separating internal thinking from user-facing responses
+
+## Message Format
+
+### Standard Message Format
+
+```json
+{
+  "role": "assistant",
+  "content": "The answer is 42."
+}
+```
+
+### Extended Message Format with Reasoning Content
+
+```json
+{
+  "role": "assistant", 
+  "content": "The answer is 42.",
+  "reasoning_content": "Let me think about this step by step. The question asks for the meaning of life, and according to The Hitchhiker's Guide to the Galaxy, the answer is 42."
+}
+```
+
+## Data Processing Behavior
+
+When processing messages during training:
+
+1. **Unmasking Rules**: Both `content` and `reasoning_content` fields follow the same unmasking rules based on the message role
+2. **Template Integration**: Both fields are processed by the chat template and included in the tokenized output
+3. **Token Wrapping**: If a role is configured to be unmasked, both fields (when present) are wrapped with unmask tokens
+4. **Independent Fields**: Either field can exist independently - messages can have only `content`, only `reasoning_content`, or both
+
+## Usage Examples
+
+### Training Data with Reasoning Traces
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is 15 * 23?"
+    },
+    {
+      "role": "assistant",
+      "reasoning_content": "I need to multiply 15 by 23. Let me break this down: 15 * 23 = 15 * (20 + 3) = 15 * 20 + 15 * 3 = 300 + 45 = 345",
+      "content": "15 * 23 = 345"
+    }
+  ]
+}
+```
+
+### Mixed Content Types
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "Solve this math problem step by step: 2x + 5 = 13"
+    },
+    {
+      "role": "assistant",
+      "reasoning_content": "I need to solve for x. First, I'll subtract 5 from both sides: 2x = 8. Then divide by 2: x = 4.",
+      "content": "To solve 2x + 5 = 13:\n1. Subtract 5 from both sides: 2x = 8\n2. Divide by 2: x = 4\n\nTherefore, x = 4."
+    }
+  ]
+}
+```
+
+### Reasoning-Only Responses
+
+```json
+{
+  "messages": [
+    {
+      "role": "user", 
+      "content": "Think about the implications of AI safety."
+    },
+    {
+      "role": "assistant",
+      "reasoning_content": "This is a complex topic that requires careful consideration of multiple factors including alignment, capability control, and social implications..."
+    }
+  ]
+}
+```
+
+## Implementation Details
+
+### Token Processing
+
+During data processing, the library:
+
+1. Wraps both `content` and `reasoning_content` with special unmask tokens (`<|UNMASK_BEGIN|>`, `<|UNMASK_END|>`, `<|UNMASK_REASONING_BEGIN|>`, `<|UNMASK_REASONING_END|>`)
+2. Applies the chat template to the combined message content
+3. Processes the tokenized sequence to create appropriate labels for training
+4. Removes the special unmask tokens from the final training data
+
+### Validation
+
+The library validates that:
+
+- Both `content` and `reasoning_content` must be strings if present
+- Special unmask tokens are properly processed and removed
+- The final training data contains no residual unmask tokens
+
+### Error Handling
+
+Common errors and their meanings:
+
+- `"unmasking non-string data types is currently unsupported"`: The `content` field contains non-string data
+- `"received an entry for reasoning_content which was not a string"`: The `reasoning_content` field contains non-string data
+
+## Integration with Existing Features
+
+### Unmasking Policies
+
+The `reasoning_content` field respects all existing unmasking policies:
+
+- When `unmask=true` is set on a sample, both fields are unmasked for non-system roles
+- When `unmask=false` (default), only assistant role messages are unmasked
+- Custom unmask role configurations work with both fields
+
+### Chat Templates
+
+The `reasoning_content` is unsupported by the legacy chat templates and will not be rendered.
+
+### Backward Compatibility
+
+The feature is fully backward compatible:
+
+- Existing datasets without `reasoning_content` continue to work unchanged
+- All existing training configurations and arguments remain valid
+
+## Testing
+
+The library includes comprehensive tests for reasoning content functionality:
+
+- Unit tests for message wrapping and processing
+- Integration tests with real tokenizers
+- Validation tests for error conditions
+- Backward compatibility tests
+
+## Important Notes
+
+### Automatic Processing Behavior
+
+1. **Always processed when present**: If `reasoning_content` exists in a message, it will always be processed and unmasked as long as the message role is targeted for unmasking. This ensures that reasoning traces are properly included in the training data without requiring additional configuration.
+
+2. **DeepSeek R1 and Qwen3 compatibility**: Models using the DeepSeek R1 thought processor (such as Qwen3) **must** supply their thinking traces in the `reasoning_content` field to be processed correctly. Failure to do so may result in improper handling of reasoning tokens and suboptimal training performance.
+
+3. **Separate token handling**: The library uses distinct unmask tokens for reasoning content (`<|UNMASK_REASONING_BEGIN|>` and `<|UNMASK_REASONING_END|>`) versus regular content (`<|UNMASK_BEGIN|>` and `<|UNMASK_END|>`), allowing for proper differentiation during training.
+
+## Best Practices
+
+1. **Consistent Usage**: When applicable, use `reasoning_content` consistently within a dataset for best results
+2. **Clear Separation**: Keep reasoning traces separate from final outputs for clarity
+3. **Template Compatibility**: Ensure your chat template properly handles both fields
+4. **Validation**: Test your data processing pipeline with small samples before full training
+
+## Migration Guide
+
+To add reasoning content support to existing datasets:
+
+1. Add `reasoning_content` fields to relevant messages
+2. Ensure content is in string format
+3. Test with a small sample using the data processing pipeline
+4. Verify that unmask tokens are properly processed
+
+No changes to training arguments or configuration are required.

--- a/src/instructlab/training/type_definitions.py
+++ b/src/instructlab/training/type_definitions.py
@@ -10,14 +10,35 @@ TODO (osilkin):
 # Standard
 import typing as t
 
+# For Python 3.8+ compatibility
+try:
+    # Standard
+    from typing import NotRequired, Required
+except ImportError:
+    try:
+        # Third Party
+        from typing_extensions import NotRequired, Required
+    except ImportError:
+        # Fallback for older Python versions
+        Required = t.Annotated
+        NotRequired = t.Annotated
+
 
 class Message(t.TypedDict):
     """
     Format of a single message sample.
+
+    Fields:
+        content: The main content of the message.
+        role: The role of the message sender (e.g., "user", "assistant", "system").
+        reasoning_content: Optional reasoning trace or thinking process associated with the message.
+                          This field is particularly useful for training reasoning-capable models
+                          that can separate their thinking process from their final output.
     """
 
-    content: str
-    role: str
+    content: Required[str]
+    role: Required[str]
+    reasoning_content: NotRequired[str]
 
 
 class ProcessedMessagesData(t.TypedDict):

--- a/tests/unit/test_data_process.py
+++ b/tests/unit/test_data_process.py
@@ -28,11 +28,498 @@ from instructlab.training.data_process import (
     MASK_TOKEN,
     UNMASK_BEGIN_TOKEN,
     UNMASK_END_TOKEN,
+    UNMASK_REASONING_BEGIN_TOKEN,
+    UNMASK_REASONING_END_TOKEN,
     unmask_messages,
     unmask_sample,
     wrap_masked_messages,
 )
 from instructlab.training.type_definitions import Message, ProcessedMessagesData
+
+
+class TestComprehensiveUnmasking(unittest.TestCase):
+    """Comprehensive test suite for unmasking behavior across various scenarios."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Mock tokenizer for basic tests
+        if TRANSFORMERS_AVAILABLE:
+            self.mock_tokenizer = Mock(spec=PreTrainedTokenizer)
+        else:
+            self.mock_tokenizer = Mock()
+
+        # Set up token IDs for unmask tokens
+        self.unmask_begin_id = 1001
+        self.unmask_end_id = 1002
+        self.eos_id = 1003
+        self.think_id = 1004
+        self.end_think_id = 1005
+
+        def mock_encode_special(text, add_special_tokens=False):
+            if text == UNMASK_BEGIN_TOKEN:
+                return [self.unmask_begin_id]
+            elif text == UNMASK_END_TOKEN:
+                return [self.unmask_end_id]
+            elif text == "</s>":
+                return [self.eos_id]
+            elif text == "<think>":
+                return [self.think_id]
+            elif text == "</think>":
+                return [self.end_think_id]
+            else:
+                # Simple hash-based encoding for text
+                return [hash(text) % 1000 + 100 for _ in text.split()]
+
+        self.mock_tokenizer.encode.side_effect = mock_encode_special
+        self.mock_tokenizer.decode.side_effect = lambda tokens: " ".join(
+            [f"token_{t}" for t in tokens]
+        )
+        self.mock_tokenizer.apply_chat_template.side_effect = (
+            self._mock_apply_chat_template
+        )
+        self.mock_tokenizer.eos_token = "</s>"
+
+    def _mock_apply_chat_template(
+        self,
+        messages: t.List[Message],
+        tokenize: bool = True,
+        add_special_tokens: bool = True,
+    ) -> t.Union[str, t.List[int]]:
+        """Mock implementation of apply_chat_template."""
+        template_tokens = []
+
+        for msg in messages:
+            # Add role tokens
+            role_tokens = [hash(f"<|{msg['role']}|>") % 1000 + 2000]
+            template_tokens.extend(role_tokens)
+
+            # Add content tokens
+            if "content" in msg and msg["content"]:
+                content_tokens = [
+                    hash(msg["content"]) % 1000 + 3000 for _ in msg["content"].split()
+                ]
+                template_tokens.extend(content_tokens)
+
+            # Add reasoning content tokens
+            if "reasoning_content" in msg and msg["reasoning_content"]:
+                reasoning_tokens = [
+                    hash(msg["reasoning_content"]) % 1000 + 4000
+                    for _ in msg["reasoning_content"].split()
+                ]
+                template_tokens.extend(reasoning_tokens)
+
+        if tokenize:
+            return template_tokens
+        else:
+            return " ".join([f"token_{t}" for t in template_tokens])
+
+    def test_single_turn_assistant_only_content(self):
+        """Test basic single-turn conversation with assistant content only."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+
+        result = unmask_messages(messages, self.mock_tokenizer, ["assistant"])
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("input_ids", result)
+        self.assertIn("labels", result)
+        self.assertIn("len", result)
+        self.assertEqual(len(result["input_ids"]), len(result["labels"]))
+
+        # Verify unmask tokens are not in final output
+        self.assertNotIn(self.unmask_begin_id, result["input_ids"])
+        self.assertNotIn(self.unmask_end_id, result["input_ids"])
+        self.assertNotIn(self.unmask_begin_id, result["labels"])
+        self.assertNotIn(self.unmask_end_id, result["labels"])
+
+    def test_single_turn_assistant_only_reasoning(self):
+        """Test single-turn with assistant reasoning_content only."""
+        messages = [
+            {"role": "user", "content": "What is 2+2?"},
+            {
+                "role": "assistant",
+                "reasoning_content": "I need to add 2 and 2 together.",
+            },
+        ]
+
+        result = unmask_messages(messages, self.mock_tokenizer, ["assistant"])
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("input_ids", result)
+        self.assertIn("labels", result)
+        self.assertIn("len", result)
+        self.assertEqual(len(result["input_ids"]), len(result["labels"]))
+
+    def test_single_turn_assistant_both_content_and_reasoning(self):
+        """Test single-turn with both content and reasoning_content."""
+        messages = [
+            {"role": "user", "content": "What is 2+2?"},
+            {
+                "role": "assistant",
+                "content": "The answer is 4.",
+                "reasoning_content": "I need to add 2 and 2 together.",
+            },
+        ]
+
+        result = unmask_messages(messages, self.mock_tokenizer, ["assistant"])
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("input_ids", result)
+        self.assertIn("labels", result)
+        self.assertIn("len", result)
+        self.assertEqual(len(result["input_ids"]), len(result["labels"]))
+
+    def test_multi_turn_conversation_basic(self):
+        """Test basic multi-turn conversation."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi! How can I help?"},
+            {"role": "user", "content": "What's the weather like?"},
+            {
+                "role": "assistant",
+                "content": "I don't have access to current weather data.",
+            },
+        ]
+
+        result = unmask_messages(messages, self.mock_tokenizer, ["assistant"])
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("input_ids", result)
+        self.assertIn("labels", result)
+        self.assertIn("len", result)
+        self.assertEqual(len(result["input_ids"]), len(result["labels"]))
+
+    def test_multi_turn_with_reasoning_content(self):
+        """Test multi-turn conversation with reasoning content in multiple turns."""
+        messages = [
+            {"role": "user", "content": "What is 5*7?"},
+            {
+                "role": "assistant",
+                "content": "35",
+                "reasoning_content": "5 times 7 equals 35",
+            },
+            {"role": "user", "content": "What about 6*8?"},
+            {
+                "role": "assistant",
+                "content": "48",
+                "reasoning_content": "6 times 8 equals 48",
+            },
+        ]
+
+        result = unmask_messages(messages, self.mock_tokenizer, ["assistant"])
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("input_ids", result)
+        self.assertIn("labels", result)
+        self.assertIn("len", result)
+        self.assertEqual(len(result["input_ids"]), len(result["labels"]))
+
+    def test_multi_turn_mixed_content_types(self):
+        """Test multi-turn with mixed content types (some with reasoning, some without)."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},  # No reasoning
+            {"role": "user", "content": "What is 2+2?"},
+            {
+                "role": "assistant",
+                "content": "The answer is 4.",
+                "reasoning_content": "I need to add 2 and 2.",
+            },  # Both content and reasoning
+            {"role": "user", "content": "Think about the meaning of life."},
+            {
+                "role": "assistant",
+                "reasoning_content": "This is a deep philosophical question.",
+            },  # Reasoning only
+        ]
+
+        result = unmask_messages(messages, self.mock_tokenizer, ["assistant"])
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("input_ids", result)
+        self.assertIn("labels", result)
+        self.assertIn("len", result)
+        self.assertEqual(len(result["input_ids"]), len(result["labels"]))
+
+    def test_system_user_assistant_conversation(self):
+        """Test conversation with system, user, and assistant roles."""
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is AI?"},
+            {
+                "role": "assistant",
+                "content": "AI stands for Artificial Intelligence.",
+                "reasoning_content": "This is a straightforward definition question.",
+            },
+        ]
+
+        # Test unmasking only assistant
+        result = unmask_messages(messages, self.mock_tokenizer, ["assistant"])
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result["input_ids"]), len(result["labels"]))
+
+    def test_multiple_unmask_roles(self):
+        """Test unmasking multiple roles."""
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {
+                "role": "user",
+                "content": "Question about math?",
+                "reasoning_content": "I'm asking about mathematics.",
+            },
+            {
+                "role": "assistant",
+                "content": "Sure, I can help with math.",
+                "reasoning_content": "Math questions are common.",
+            },
+        ]
+
+        # Test unmasking both user and assistant
+        result = unmask_messages(messages, self.mock_tokenizer, ["user", "assistant"])
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result["input_ids"]), len(result["labels"]))
+
+    def test_reasoning_only_conversation(self):
+        """Test conversation where all assistant messages have only reasoning_content."""
+        messages = [
+            {"role": "user", "content": "Think step by step."},
+            {"role": "assistant", "reasoning_content": "Step 1: Consider the problem."},
+            {"role": "user", "content": "Continue."},
+            {"role": "assistant", "reasoning_content": "Step 2: Analyze the solution."},
+        ]
+
+        result = unmask_messages(messages, self.mock_tokenizer, ["assistant"])
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result["input_ids"]), len(result["labels"]))
+
+    def test_empty_content_edge_cases(self):
+        """Test edge cases with empty content."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "Empty content case",
+            },
+            {"role": "user", "content": "Continue"},
+            {"role": "assistant", "content": "Response", "reasoning_content": ""},
+        ]
+
+        result = unmask_messages(messages, self.mock_tokenizer, ["assistant"])
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result["input_ids"]), len(result["labels"]))
+
+    def test_consecutive_assistant_messages(self):
+        """Test consecutive assistant messages (simulating the Qwen scenario)."""
+        messages = [
+            {"role": "user", "content": "First question"},
+            {
+                "role": "assistant",
+                "content": "First response A",
+                "reasoning_content": "Reasoning A",
+            },
+            {"role": "user", "content": "Second question"},
+            {
+                "role": "assistant",
+                "content": "Second response B",
+                "reasoning_content": "Reasoning B",
+            },
+            {
+                "role": "assistant",
+                "content": "Third response C",
+                "reasoning_content": "Reasoning C",
+            },
+        ]
+
+        result = unmask_messages(messages, self.mock_tokenizer, ["assistant"])
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result["input_ids"]), len(result["labels"]))
+
+    def test_long_multi_turn_conversation(self):
+        """Test long multi-turn conversation with various content types."""
+        messages = []
+        for i in range(10):
+            messages.append({"role": "user", "content": f"User message {i}"})
+
+            if i % 3 == 0:
+                # Content only
+                messages.append(
+                    {"role": "assistant", "content": f"Assistant response {i}"}
+                )
+            elif i % 3 == 1:
+                # Reasoning only
+                messages.append(
+                    {"role": "assistant", "reasoning_content": f"Reasoning {i}"}
+                )
+            else:
+                # Both content and reasoning
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": f"Response {i}",
+                        "reasoning_content": f"Reasoning {i}",
+                    }
+                )
+
+        result = unmask_messages(messages, self.mock_tokenizer, ["assistant"])
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result["input_ids"]), len(result["labels"]))
+
+    def test_unmask_sample_function(self):
+        """Test the unmask_sample function with various scenarios."""
+        sample_scenarios = [
+            # Basic conversation
+            {
+                "messages": [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi!"},
+                ]
+            },
+            # With reasoning content
+            {
+                "messages": [
+                    {"role": "user", "content": "What is 2+2?"},
+                    {
+                        "role": "assistant",
+                        "content": "4",
+                        "reasoning_content": "2 plus 2 equals 4",
+                    },
+                ]
+            },
+            # With unmask flag
+            {
+                "messages": [
+                    {"role": "user", "content": "Question"},
+                    {"role": "assistant", "content": "Answer"},
+                ],
+                "unmask": True,
+            },
+            # Multi-turn with system
+            {
+                "messages": [
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "Question"},
+                    {"role": "assistant", "content": "Answer"},
+                ]
+            },
+        ]
+
+        for i, sample in enumerate(sample_scenarios):
+            with self.subTest(scenario=i):
+                result = unmask_sample(sample, self.mock_tokenizer)
+                self.assertIsInstance(result, dict)
+                self.assertIn("input_ids", result)
+                self.assertIn("labels", result)
+                self.assertIn("len", result)
+                self.assertEqual(len(result["input_ids"]), len(result["labels"]))
+
+    def test_wrap_masked_messages_comprehensive(self):
+        """Test wrap_masked_messages with comprehensive scenarios."""
+        test_cases = [
+            # Single role, content only
+            {
+                "messages": [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi"},
+                ],
+                "unmask_roles": ["assistant"],
+                "expected_wrapped_count": 1,
+            },
+            # Single role, reasoning only
+            {
+                "messages": [
+                    {"role": "user", "content": "Think"},
+                    {"role": "assistant", "reasoning_content": "Thinking..."},
+                ],
+                "unmask_roles": ["assistant"],
+                "expected_wrapped_count": 1,
+            },
+            # Single role, both content types
+            {
+                "messages": [
+                    {"role": "user", "content": "Question"},
+                    {
+                        "role": "assistant",
+                        "content": "Answer",
+                        "reasoning_content": "Thinking",
+                    },
+                ],
+                "unmask_roles": ["assistant"],
+                "expected_wrapped_count": 2,  # Both content and reasoning_content wrapped
+            },
+            # Multiple roles
+            {
+                "messages": [
+                    {"role": "system", "content": "System message"},
+                    {
+                        "role": "user",
+                        "content": "User question",
+                        "reasoning_content": "User thinking",
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "Assistant answer",
+                        "reasoning_content": "Assistant thinking",
+                    },
+                ],
+                "unmask_roles": ["user", "assistant"],
+                "expected_wrapped_count": 4,  # 2 messages × 2 fields each
+            },
+        ]
+
+        for i, case in enumerate(test_cases):
+            with self.subTest(case=i):
+                result = wrap_masked_messages(
+                    case["messages"], case["unmask_roles"], True
+                )
+
+                # Count wrapped fields
+                wrapped_count = 0
+                for msg in result:
+                    if msg["role"] in case["unmask_roles"]:
+                        if msg.get("content") and UNMASK_BEGIN_TOKEN in msg["content"]:
+                            wrapped_count += 1
+                        if (
+                            msg.get("reasoning_content")
+                            and UNMASK_REASONING_BEGIN_TOKEN in msg["reasoning_content"]
+                        ):
+                            wrapped_count += 1
+
+                self.assertEqual(wrapped_count, case["expected_wrapped_count"])
+
+    def test_error_conditions(self):
+        """Test various error conditions."""
+        # Test non-string content
+        with self.assertRaises(ValueError):
+            wrap_masked_messages(
+                [{"role": "assistant", "content": ["not", "a", "string"]}],
+                ["assistant"],
+                True,
+            )
+
+        # Test non-string reasoning_content
+        with self.assertRaises(ValueError):
+            wrap_masked_messages(
+                [{"role": "assistant", "reasoning_content": {"not": "a string"}}],
+                ["assistant"],
+                True,
+            )
+
+    def test_think_tag_handling(self):
+        """Test that <think> and </think> tags are properly handled."""
+        # This is a basic test since the mock tokenizer handles think tags
+        messages = [
+            {"role": "user", "content": "Question with <think>thinking</think>"},
+            {
+                "role": "assistant",
+                "content": "Answer with <think>more thinking</think>",
+            },
+        ]
+
+        result = unmask_messages(messages, self.mock_tokenizer, ["assistant"])
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result["input_ids"]), len(result["labels"]))
 
 
 class TestReasoningContentSupport(unittest.TestCase):
@@ -61,6 +548,8 @@ class TestReasoningContentSupport(unittest.TestCase):
         # Set up token IDs for unmask tokens
         self.unmask_begin_id = 1001
         self.unmask_end_id = 1002
+        self.unmask_reasoning_begin_id = 1004
+        self.unmask_reasoning_end_id = 1005
         self.eos_id = 1003
 
         def mock_encode_special(text, add_special_tokens=False):
@@ -68,6 +557,10 @@ class TestReasoningContentSupport(unittest.TestCase):
                 return [self.unmask_begin_id]
             elif text == UNMASK_END_TOKEN:
                 return [self.unmask_end_id]
+            elif text == UNMASK_REASONING_BEGIN_TOKEN:
+                return [self.unmask_reasoning_begin_id]
+            elif text == UNMASK_REASONING_END_TOKEN:
+                return [self.unmask_reasoning_end_id]
             elif text == "</s>":
                 return [self.eos_id]
             else:
@@ -111,7 +604,7 @@ class TestReasoningContentSupport(unittest.TestCase):
         ]
 
         unmask_roles = ["assistant"]
-        result = wrap_masked_messages(messages, unmask_roles)
+        result = wrap_masked_messages(messages, unmask_roles, True)
 
         # Check that user message is unchanged
         self.assertEqual(result[0]["role"], "user")
@@ -126,7 +619,7 @@ class TestReasoningContentSupport(unittest.TestCase):
         )
         self.assertEqual(
             result[1]["reasoning_content"],
-            f"{UNMASK_BEGIN_TOKEN}I need to add 2 and 2 together. 2 + 2 = 4.{UNMASK_END_TOKEN}",
+            f"{UNMASK_REASONING_BEGIN_TOKEN}I need to add 2 and 2 together. 2 + 2 = 4.{UNMASK_REASONING_END_TOKEN}",
         )
 
     def test_wrap_masked_messages_content_only(self):
@@ -143,7 +636,7 @@ class TestReasoningContentSupport(unittest.TestCase):
         ]
 
         unmask_roles = ["assistant"]
-        result = wrap_masked_messages(messages, unmask_roles)
+        result = wrap_masked_messages(messages, unmask_roles, True)
 
         # Check that user message is unchanged
         self.assertEqual(result[0]["role"], "user")
@@ -171,7 +664,7 @@ class TestReasoningContentSupport(unittest.TestCase):
         ]
 
         unmask_roles = ["assistant"]
-        result = wrap_masked_messages(messages, unmask_roles)
+        result = wrap_masked_messages(messages, unmask_roles, True)
 
         # Check that user message is unchanged
         self.assertEqual(result[0]["role"], "user")
@@ -181,7 +674,7 @@ class TestReasoningContentSupport(unittest.TestCase):
         self.assertEqual(result[1]["role"], "assistant")
         self.assertEqual(
             result[1]["reasoning_content"],
-            f"{UNMASK_BEGIN_TOKEN}Let me think about this step by step...{UNMASK_END_TOKEN}",
+            f"{UNMASK_REASONING_BEGIN_TOKEN}Let me think about this step by step...{UNMASK_REASONING_END_TOKEN}",
         )
         self.assertNotIn("content", result[1])
 
@@ -205,7 +698,7 @@ class TestReasoningContentSupport(unittest.TestCase):
         ]
 
         unmask_roles = ["user", "assistant"]
-        result = wrap_masked_messages(messages, unmask_roles)
+        result = wrap_masked_messages(messages, unmask_roles, True)
 
         # Check that system message is unchanged
         self.assertEqual(result[0]["role"], "system")
@@ -219,7 +712,7 @@ class TestReasoningContentSupport(unittest.TestCase):
         )
         self.assertEqual(
             result[1]["reasoning_content"],
-            f"{UNMASK_BEGIN_TOKEN}This is a geography question about France.{UNMASK_END_TOKEN}",
+            f"{UNMASK_REASONING_BEGIN_TOKEN}This is a geography question about France.{UNMASK_REASONING_END_TOKEN}",
         )
 
         # Check that assistant message has both fields wrapped
@@ -230,7 +723,7 @@ class TestReasoningContentSupport(unittest.TestCase):
         )
         self.assertEqual(
             result[2]["reasoning_content"],
-            f"{UNMASK_BEGIN_TOKEN}This is a straightforward geography question.{UNMASK_END_TOKEN}",
+            f"{UNMASK_REASONING_BEGIN_TOKEN}This is a straightforward geography question.{UNMASK_REASONING_END_TOKEN}",
         )
 
     def test_wrap_masked_messages_non_string_content_error(self):
@@ -245,7 +738,7 @@ class TestReasoningContentSupport(unittest.TestCase):
         unmask_roles = ["assistant"]
 
         with self.assertRaises(ValueError) as context:
-            wrap_masked_messages(messages, unmask_roles)
+            wrap_masked_messages(messages, unmask_roles, True)
 
         self.assertIn(
             "unmasking non-string data types is currently unsupported",
@@ -265,7 +758,7 @@ class TestReasoningContentSupport(unittest.TestCase):
         unmask_roles = ["assistant"]
 
         with self.assertRaises(ValueError) as context:
-            wrap_masked_messages(messages, unmask_roles)
+            wrap_masked_messages(messages, unmask_roles, True)
 
         self.assertIn(
             "received an entry for `reasoning_content` which was not a string",
@@ -291,13 +784,13 @@ class TestReasoningContentSupport(unittest.TestCase):
         unmask_roles = ["assistant"]
 
         # Test that wrap_masked_messages works correctly with reasoning_content
-        wrapped = wrap_masked_messages(messages, unmask_roles)
+        wrapped = wrap_masked_messages(messages, unmask_roles, True)
 
         # Verify that both content and reasoning_content are wrapped
         self.assertIn(UNMASK_BEGIN_TOKEN, wrapped[1]["content"])
         self.assertIn(UNMASK_END_TOKEN, wrapped[1]["content"])
-        self.assertIn(UNMASK_BEGIN_TOKEN, wrapped[1]["reasoning_content"])
-        self.assertIn(UNMASK_END_TOKEN, wrapped[1]["reasoning_content"])
+        self.assertIn(UNMASK_REASONING_BEGIN_TOKEN, wrapped[1]["reasoning_content"])
+        self.assertIn(UNMASK_REASONING_END_TOKEN, wrapped[1]["reasoning_content"])
 
         # Verify the user message is unchanged
         self.assertEqual(wrapped[0]["content"], "What is 5*7?")
@@ -362,7 +855,7 @@ class TestReasoningContentWithRealTokenizers(unittest.TestCase):
         """Test reasoning_content functionality with Qwen3-32B tokenizer."""
         try:
             # Use a smaller Qwen model that's more readily available
-            tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct")
+            tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-32B")
         except Exception as e:
             self.skipTest(f"Qwen tokenizer not available: {e}")
 
@@ -372,6 +865,8 @@ class TestReasoningContentWithRealTokenizers(unittest.TestCase):
                 "additional_special_tokens": [
                     UNMASK_BEGIN_TOKEN,
                     UNMASK_END_TOKEN,
+                    UNMASK_REASONING_BEGIN_TOKEN,
+                    UNMASK_REASONING_END_TOKEN,
                     MASK_TOKEN,
                 ]
             }
@@ -390,13 +885,13 @@ class TestReasoningContentWithRealTokenizers(unittest.TestCase):
         ]
 
         # Test wrap_masked_messages
-        wrapped = wrap_masked_messages(messages, ["assistant"])
+        wrapped = wrap_masked_messages(messages, ["assistant"], True)
 
         # Verify that both content and reasoning_content are wrapped
         self.assertIn(UNMASK_BEGIN_TOKEN, wrapped[1]["content"])
         self.assertIn(UNMASK_END_TOKEN, wrapped[1]["content"])
-        self.assertIn(UNMASK_BEGIN_TOKEN, wrapped[1]["reasoning_content"])
-        self.assertIn(UNMASK_END_TOKEN, wrapped[1]["reasoning_content"])
+        self.assertIn(UNMASK_REASONING_BEGIN_TOKEN, wrapped[1]["reasoning_content"])
+        self.assertIn(UNMASK_REASONING_END_TOKEN, wrapped[1]["reasoning_content"])
 
         # Test unmask_messages
         result = unmask_messages(messages, tokenizer, ["assistant"])
@@ -432,6 +927,8 @@ class TestReasoningContentWithRealTokenizers(unittest.TestCase):
                 "additional_special_tokens": [
                     UNMASK_BEGIN_TOKEN,
                     UNMASK_END_TOKEN,
+                    UNMASK_REASONING_BEGIN_TOKEN,
+                    UNMASK_REASONING_END_TOKEN,
                     MASK_TOKEN,
                 ]
             }
@@ -471,10 +968,10 @@ class TestReasoningContentWithRealTokenizers(unittest.TestCase):
             }
         ]
 
-        wrapped = wrap_masked_messages(messages, ["assistant"])
+        wrapped = wrap_masked_messages(messages, ["assistant"], True)
         self.assertEqual(
             wrapped[0]["reasoning_content"],
-            f"{UNMASK_BEGIN_TOKEN}{UNMASK_END_TOKEN}",
+            f"{UNMASK_REASONING_BEGIN_TOKEN}{UNMASK_REASONING_END_TOKEN}",
         )
 
         # Test only reasoning_content without content
@@ -485,11 +982,11 @@ class TestReasoningContentWithRealTokenizers(unittest.TestCase):
             }
         ]
 
-        wrapped = wrap_masked_messages(messages, ["assistant"])
+        wrapped = wrap_masked_messages(messages, ["assistant"], True)
         self.assertNotIn("content", wrapped[0])
         self.assertEqual(
             wrapped[0]["reasoning_content"],
-            f"{UNMASK_BEGIN_TOKEN}Thinking process{UNMASK_END_TOKEN}",
+            f"{UNMASK_REASONING_BEGIN_TOKEN}Thinking process{UNMASK_REASONING_END_TOKEN}",
         )
 
 

--- a/tests/unit/test_reasoning_unmask.py
+++ b/tests/unit/test_reasoning_unmask.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""
+Comprehensive tests for reasoning content unmasking functionality.
+Tests the merging of reasoning and content unmask regions as described
+in the InstructLab training documentation.
+"""
+
+# Standard
+from unittest.mock import Mock
+
+# Third Party
+from transformers import AutoTokenizer
+import pytest
+
+# First Party
+from instructlab.training.data_process import (
+    UNMASK_BEGIN_TOKEN,
+    UNMASK_END_TOKEN,
+    UNMASK_REASONING_BEGIN_TOKEN,
+    UNMASK_REASONING_END_TOKEN,
+    unmask_messages,
+    wrap_masked_messages,
+)
+
+
+class TestReasoningContentUnmasking:
+    """Test suite for reasoning content unmasking with region merging."""
+
+    @pytest.fixture
+    def mock_tokenizer(self):
+        """Create a mock tokenizer with all necessary tokens."""
+        tokenizer = Mock()
+
+        # Mock token encoding
+        def mock_encode(text, add_special_tokens=False):
+            token_map = {
+                UNMASK_BEGIN_TOKEN: [1000],
+                UNMASK_END_TOKEN: [1001],
+                UNMASK_REASONING_BEGIN_TOKEN: [1002],
+                UNMASK_REASONING_END_TOKEN: [1003],
+                "<|endoftext|>": [50256],
+                "<|im_end|>": [50257],
+                "<|im_start|>": [50258],
+                "<think>": [50259],
+                "</think>": [50260],
+                "\n\n": [50261],
+            }
+            # For unknown text, return a hash-based token
+            return token_map.get(text, [hash(text) % 10000 + 100])
+
+        tokenizer.encode = mock_encode
+        tokenizer.eos_token = "<|im_end|>"
+
+        return tokenizer
+
+    def test_reasoning_content_merging_basic(self, mock_tokenizer):
+        """Test basic merging of reasoning and content regions."""
+        messages = [
+            {"role": "user", "content": "Where is Paris?"},
+            {
+                "role": "assistant",
+                "content": "Paris is in Europe",
+                "reasoning_content": "Paris is the capital of France, France is in Europe",
+            },
+        ]
+
+        # Simulate Qwen/DeepSeek style template output:
+        # <|im_start|>user\nWhere is Paris?<|im_end|>
+        # <|im_start|>assistant\n<think>\n[REASONING]\n</think>\n\n[CONTENT]<|im_end|>
+        mock_tokenizer.apply_chat_template.return_value = [
+            50258,
+            100,
+            101,
+            50257,  # user message
+            50258,
+            200,  # <|im_start|>assistant
+            50259,  # <think>
+            1002,
+            300,
+            301,
+            1003,  # wrapped reasoning content
+            50260,  # </think>
+            50261,  # \n\n
+            1000,
+            400,
+            401,
+            402,
+            1001,  # wrapped content
+            50257,  # <|im_end|>
+        ]
+
+        result = unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+        # The unmask regions should be merged, unmasking everything from reasoning to content
+        # including the </think> and \n\n tokens
+        expected_unmasked_tokens = [300, 301, 50260, 50261, 400, 401, 402, 50257]
+
+        # Verify that all expected tokens are unmasked
+        for tok in expected_unmasked_tokens:
+            if tok in result["input_ids"]:
+                # For tokens that appear multiple times, check if at least one is unmasked
+                indices = [i for i, t in enumerate(result["input_ids"]) if t == tok]
+                assert any(result["labels"][i] == tok for i in indices), (
+                    f"Token {tok} not unmasked"
+                )
+
+    def test_reasoning_content_no_merging_when_different_messages(self, mock_tokenizer):
+        """Test that regions are not merged when they belong to different messages."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Answer1",
+                "reasoning_content": "Thinking1",
+            },
+            {
+                "role": "assistant",
+                "content": "Answer2",
+                "reasoning_content": "Thinking2",
+            },
+        ]
+
+        # Simulate regions from two different assistant messages
+        mock_tokenizer.apply_chat_template.return_value = [
+            # First message
+            1002,
+            100,
+            1003,  # reasoning region for message 1
+            1000,
+            200,
+            1001,  # content region for message 1
+            50257,  # EOS
+            # Second message
+            1002,
+            300,
+            1003,  # reasoning region for message 2
+            1000,
+            400,
+            1001,  # content region for message 2
+            50257,  # EOS
+        ]
+
+        result = unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+        # All regions should be unmasked, but first message's regions should be separate from second's
+        assert 100 in result["input_ids"]  # reasoning 1
+        assert 200 in result["input_ids"]  # content 1
+        assert 300 in result["input_ids"]  # reasoning 2
+        assert 400 in result["input_ids"]  # content 2
+
+        # Both messages' content should be unmasked
+        for tok in [100, 200, 300, 400]:
+            idx = result["input_ids"].index(tok)
+            assert result["labels"][idx] == tok
+
+    def test_multiple_assistant_messages_with_reasoning(self, mock_tokenizer):
+        """Test handling of multiple assistant messages with reasoning content."""
+        messages = [
+            {"role": "user", "content": "Question 1"},
+            {
+                "role": "assistant",
+                "content": "Answer 1",
+                "reasoning_content": "Thinking 1",
+            },
+            {"role": "user", "content": "Question 2"},
+            {
+                "role": "assistant",
+                "content": "Answer 2",
+                "reasoning_content": "Thinking 2",
+            },
+        ]
+
+        # Simulate chat template output with two assistant responses
+        mock_tokenizer.apply_chat_template.return_value = [
+            # First exchange
+            50258,
+            100,
+            50257,  # user 1
+            50258,
+            200,  # assistant start
+            50259,  # <think>
+            1002,
+            300,
+            1003,  # reasoning 1
+            50260,
+            50261,  # </think>\n\n
+            1000,
+            400,
+            1001,  # content 1
+            50257,  # <|im_end|>
+            # Second exchange
+            50258,
+            500,
+            50257,  # user 2
+            50258,
+            600,  # assistant start
+            50259,  # <think>
+            1002,
+            700,
+            1003,  # reasoning 2
+            50260,
+            50261,  # </think>\n\n
+            1000,
+            800,
+            1001,  # content 2
+            50257,  # <|im_end|>
+        ]
+
+        result = unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+        # Both assistant messages should have their reasoning and content unmasked
+        # Check first assistant response
+        assert 300 in [
+            t for i, t in enumerate(result["input_ids"]) if result["labels"][i] != -100
+        ]
+        assert 400 in [
+            t for i, t in enumerate(result["input_ids"]) if result["labels"][i] != -100
+        ]
+
+        # Check second assistant response
+        assert 700 in [
+            t for i, t in enumerate(result["input_ids"]) if result["labels"][i] != -100
+        ]
+        assert 800 in [
+            t for i, t in enumerate(result["input_ids"]) if result["labels"][i] != -100
+        ]
+
+    def test_reasoning_without_content(self, mock_tokenizer):
+        """Test messages that only have reasoning_content without regular content."""
+        messages = [
+            {"role": "user", "content": "Think about this"},
+            {"role": "assistant", "reasoning_content": "Let me think..."},
+        ]
+
+        mock_tokenizer.apply_chat_template.return_value = [
+            50258,
+            100,
+            50257,  # user
+            50258,
+            200,  # assistant start
+            50259,  # <think>
+            1002,
+            300,
+            301,
+            1003,  # reasoning
+            50260,  # </think>
+            50257,  # <|im_end|>
+        ]
+
+        result = unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+        # Reasoning content and EOS should be unmasked
+        assert 300 in result["input_ids"]
+        assert 301 in result["input_ids"]
+        assert 50257 in result["input_ids"]  # EOS token
+
+        # Check labels
+        idx_300 = result["input_ids"].index(300)
+        idx_301 = result["input_ids"].index(301)
+        # Find the last EOS token (assistant's)
+        eos_indices = [i for i, t in enumerate(result["input_ids"]) if t == 50257]
+        idx_eos = eos_indices[-1] if eos_indices else None
+
+        assert result["labels"][idx_300] == 300
+        assert result["labels"][idx_301] == 301
+        if idx_eos is not None:
+            assert result["labels"][idx_eos] == 50257
+
+    def test_content_without_reasoning(self, mock_tokenizer):
+        """Test messages that only have content without reasoning_content."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+
+        mock_tokenizer.apply_chat_template.return_value = [
+            50258,
+            100,
+            50257,  # user
+            50258,
+            200,  # assistant start
+            1000,
+            300,
+            301,
+            302,
+            1001,  # content
+            50257,  # <|im_end|>
+        ]
+
+        result = unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+        # Content and EOS should be unmasked
+        assert all(tok in result["input_ids"] for tok in [300, 301, 302, 50257])
+
+        # Verify unmasking
+        for tok in [300, 301, 302]:
+            idx = result["input_ids"].index(tok)
+            assert result["labels"][idx] == tok
+
+        # For EOS token, check the last occurrence (assistant's EOS)
+        eos_indices = [i for i, t in enumerate(result["input_ids"]) if t == 50257]
+        assert len(eos_indices) >= 1
+        last_eos_idx = eos_indices[-1]
+        assert result["labels"][last_eos_idx] == 50257
+
+    def test_reasoning_content_order_variations(self, mock_tokenizer):
+        """Test different orderings of reasoning and content regions."""
+        messages = [
+            {"role": "assistant", "content": "Answer", "reasoning_content": "Reasoning"}
+        ]
+
+        # Test content before reasoning (unusual but possible)
+        mock_tokenizer.apply_chat_template.return_value = [
+            1000,
+            100,
+            1001,  # content first
+            50261,  # separator
+            1002,
+            200,
+            1003,  # reasoning after
+            50257,  # EOS
+        ]
+
+        result = unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+        # Both regions should be merged and unmasked
+        assert 100 in result["input_ids"]
+        assert 200 in result["input_ids"]
+        assert 50257 in result["input_ids"]
+
+    def test_unmask_all_roles_with_reasoning(self, mock_tokenizer):
+        """Test unmasking all roles when some have reasoning content."""
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {
+                "role": "user",
+                "content": "Question",
+                "reasoning_content": "User thinking",
+            },
+            {
+                "role": "assistant",
+                "content": "Answer",
+                "reasoning_content": "Assistant thinking",
+            },
+        ]
+
+        mock_tokenizer.apply_chat_template.return_value = [
+            # System (no reasoning)
+            1000,
+            50,
+            1001,
+            # User with reasoning
+            1002,
+            100,
+            1003,
+            1000,
+            150,
+            1001,
+            # Assistant with reasoning
+            1002,
+            200,
+            1003,
+            1000,
+            250,
+            1001,
+            50257,
+        ]
+
+        result = unmask_messages(
+            messages, mock_tokenizer, ["system", "user", "assistant"]
+        )
+
+        # All content should be unmasked
+        unmasked_tokens = [50, 100, 150, 200, 250, 50257]
+        for tok in unmasked_tokens:
+            idx = result["input_ids"].index(tok)
+            assert result["labels"][idx] == tok
+
+    def test_edge_case_empty_reasoning_content(self, mock_tokenizer):
+        """Test handling of empty reasoning_content field."""
+        messages = [{"role": "assistant", "content": "Answer", "reasoning_content": ""}]
+
+        # Empty reasoning should still create unmask tokens but with no content between
+        mock_tokenizer.apply_chat_template.return_value = [
+            1002,
+            1003,  # empty reasoning
+            1000,
+            100,
+            1001,  # content
+            50257,
+        ]
+
+        result = unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+        # Content and EOS should be unmasked
+        assert 100 in result["input_ids"]
+        assert 50257 in result["input_ids"]
+
+    def test_complex_qwen_deepseek_scenario(self, mock_tokenizer):
+        """Test a complex scenario mimicking Qwen/DeepSeek behavior."""
+        messages = [
+            {"role": "user", "content": "What is 2+2?"},
+            {
+                "role": "assistant",
+                "content": "The answer is 4.",
+                "reasoning_content": "I need to add 2 and 2. 2 + 2 = 4.",
+            },
+            {
+                "role": "assistant",
+                "content": "Let me elaborate: it's basic arithmetic.",
+                "reasoning_content": "",
+            },
+        ]
+
+        # Simulate the complex template behavior described in the instructions
+        mock_tokenizer.apply_chat_template.return_value = [
+            50258,
+            100,
+            50257,  # user
+            50258,
+            200,  # first assistant
+            50259,  # <think>
+            1002,
+            300,
+            301,
+            302,
+            1003,  # reasoning
+            50260,  # </think>
+            50261,  # \n\n
+            1000,
+            400,
+            401,
+            1001,  # content
+            50257,  # <|im_end|>
+            50258,
+            500,  # second assistant (continuation)
+            50259,  # <think> (empty)
+            1002,
+            1003,  # empty reasoning
+            50260,  # </think>
+            50261,  # \n\n
+            1000,
+            600,
+            601,
+            602,
+            1001,  # content
+            50257,  # <|im_end|>
+        ]
+
+        result = unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+        # Both assistant messages should be properly unmasked
+        # First assistant: reasoning + content
+        for tok in [300, 301, 302, 400, 401]:
+            assert tok in result["input_ids"]
+            idx = result["input_ids"].index(tok)
+            assert result["labels"][idx] == tok
+
+        # Second assistant: content only (empty reasoning)
+        for tok in [600, 601, 602]:
+            assert tok in result["input_ids"]
+            idx = result["input_ids"].index(tok)
+            assert result["labels"][idx] == tok
+
+    def test_validation_nested_reasoning_tokens(self, mock_tokenizer):
+        """Test that nested reasoning tokens raise appropriate errors."""
+        messages = [{"role": "assistant", "content": "Test"}]
+
+        # Nested reasoning begin tokens
+        mock_tokenizer.apply_chat_template.return_value = [
+            1002,
+            100,
+            1002,
+            200,
+            1003,
+            1003,
+        ]
+
+        with pytest.raises(
+            ValueError, match="encountered.*UNMASK_REASONING.*while already unmasking"
+        ):
+            unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+    def test_known_token_ids_preserved(self, mock_tokenizer):
+        """Test that specific known token IDs are handled correctly."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Final answer",
+                "reasoning_content": "Thinking process",
+            }
+        ]
+
+        # Use specific token IDs to verify preservation
+        mock_tokenizer.apply_chat_template.return_value = [
+            50258,  # <|im_start|>
+            1002,
+            12345,
+            1003,  # reasoning with specific ID
+            50260,  # </think>
+            1000,
+            67890,
+            1001,  # content with specific ID
+            50257,  # <|im_end|>
+        ]
+
+        result = unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+        # Verify specific tokens are preserved
+        assert 12345 in result["input_ids"]
+        assert 67890 in result["input_ids"]
+
+        # Verify they're unmasked
+        idx_12345 = result["input_ids"].index(12345)
+        idx_67890 = result["input_ids"].index(67890)
+        assert result["labels"][idx_12345] == 12345
+        assert result["labels"][idx_67890] == 67890
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_unmask_messages.py
+++ b/tests/unit/test_unmask_messages.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""
+Comprehensive tests for the unmask_messages function to ensure behavior consistency
+across different tokenizers and scenarios.
+"""
+
+# Standard
+from unittest.mock import Mock, patch
+import os
+import tempfile
+
+# Third Party
+from transformers import AutoTokenizer
+import pytest
+
+# First Party
+# Import the functions we want to test
+from instructlab.training.data_process import (
+    UNMASK_BEGIN_TOKEN,
+    UNMASK_END_TOKEN,
+    UNMASK_REASONING_BEGIN_TOKEN,
+    UNMASK_REASONING_END_TOKEN,
+    unmask_messages,
+    wrap_masked_messages,
+)
+from instructlab.training.type_definitions import Message
+
+
+class TestWrapMaskedMessages:
+    """Test suite for wrap_masked_messages functionality."""
+
+    @pytest.fixture
+    def sample_messages(self):
+        """Sample messages for testing."""
+        return [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello, how are you?"},
+            {"role": "assistant", "content": "I'm doing well, thank you!"},
+        ]
+
+    @pytest.fixture
+    def reasoning_messages(self):
+        """Sample messages with reasoning content."""
+        return [
+            {"role": "user", "content": "What is 2+2?"},
+            {
+                "role": "assistant",
+                "content": "The answer is 4.",
+                "reasoning_content": "I need to add 2 and 2 together. 2 + 2 = 4.",
+            },
+        ]
+
+    def test_wrap_masked_messages_basic(self, sample_messages):
+        """Test basic message wrapping functionality."""
+        wrapped = wrap_masked_messages(sample_messages, ["assistant"])
+
+        # Check that only assistant messages are wrapped
+        assert (
+            sample_messages[0]["content"] == wrapped[0]["content"]
+        )  # system unchanged
+        assert sample_messages[1]["content"] == wrapped[1]["content"]  # user unchanged
+        assert (
+            wrapped[2]["content"]
+            == f"{UNMASK_BEGIN_TOKEN}I'm doing well, thank you!{UNMASK_END_TOKEN}"
+        )
+
+    def test_wrap_masked_messages_with_reasoning(self, reasoning_messages):
+        """Test message wrapping with reasoning content."""
+        # Test with reasoning content disabled (default behavior)
+        wrapped = wrap_masked_messages(reasoning_messages, ["assistant"])
+
+        # Check content wrapping
+        expected_content = f"{UNMASK_BEGIN_TOKEN}The answer is 4.{UNMASK_END_TOKEN}"
+        assert wrapped[1]["content"] == expected_content
+
+        # Check reasoning content is NOT processed when disabled
+        assert (
+            wrapped[1]["reasoning_content"]
+            == "I need to add 2 and 2 together. 2 + 2 = 4."
+        )
+
+        # Test with reasoning content enabled
+        wrapped_with_reasoning = wrap_masked_messages(
+            reasoning_messages, ["assistant"], enable_reasoning_content=True
+        )
+
+        # Check content is wrapped with regular tokens and reasoning with reasoning-specific tokens
+        assert wrapped_with_reasoning[1]["content"] == expected_content
+        expected_reasoning = f"{UNMASK_REASONING_BEGIN_TOKEN}I need to add 2 and 2 together. 2 + 2 = 4.{UNMASK_REASONING_END_TOKEN}"
+        assert wrapped_with_reasoning[1]["reasoning_content"] == expected_reasoning
+
+    def test_wrap_masked_messages_multiple_roles(self, sample_messages):
+        """Test wrapping messages for multiple roles."""
+        wrapped = wrap_masked_messages(sample_messages, ["user", "assistant"])
+
+        # Both user and assistant should be wrapped
+        assert (
+            wrapped[1]["content"]
+            == f"{UNMASK_BEGIN_TOKEN}Hello, how are you?{UNMASK_END_TOKEN}"
+        )
+        assert (
+            wrapped[2]["content"]
+            == f"{UNMASK_BEGIN_TOKEN}I'm doing well, thank you!{UNMASK_END_TOKEN}"
+        )
+        # System should remain unchanged
+        assert wrapped[0]["content"] == sample_messages[0]["content"]
+
+    def test_wrap_masked_messages_error_on_non_string_content(self):
+        """Test that wrapping non-string content raises an error."""
+        messages = [{"role": "assistant", "content": ["not", "a", "string"]}]
+
+        with pytest.raises(ValueError, match="unmasking non-string data types"):
+            wrap_masked_messages(messages, ["assistant"])
+
+    def test_wrap_masked_messages_empty_roles_list(self, sample_messages):
+        """Test wrapping with empty roles list."""
+        wrapped = wrap_masked_messages(sample_messages, [])
+
+        # All messages should remain unchanged
+        for i, msg in enumerate(sample_messages):
+            assert wrapped[i]["content"] == msg["content"]
+
+    def test_wrap_masked_messages_preserves_other_fields(self):
+        """Test that other message fields are preserved during wrapping."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Hello",
+                "custom_field": "custom_value",
+                "another_field": 123,
+            }
+        ]
+        wrapped = wrap_masked_messages(messages, ["assistant"])
+
+        assert wrapped[0]["custom_field"] == "custom_value"
+        assert wrapped[0]["another_field"] == 123
+        assert wrapped[0]["role"] == "assistant"
+
+
+class TestUnmaskMessages:
+    """Test suite for unmask_messages functionality."""
+
+    @pytest.fixture
+    def mock_tokenizer(self):
+        """Create a mock tokenizer for basic testing."""
+        tokenizer = Mock()
+
+        # Mock the special token encodings
+        def mock_encode(text, add_special_tokens=False):
+            token_map = {
+                UNMASK_BEGIN_TOKEN: [1000],
+                UNMASK_END_TOKEN: [1001],
+                UNMASK_REASONING_BEGIN_TOKEN: [1002],
+                UNMASK_REASONING_END_TOKEN: [1003],
+                "<|endoftext|>": [0],
+            }
+            return token_map.get(text, [hash(text) % 500 + 100])
+
+        tokenizer.encode = mock_encode
+        tokenizer.eos_token = "<|endoftext|>"
+
+        return tokenizer
+
+    @pytest.fixture
+    def simple_input_ids(self):
+        """Simple token sequence for testing: user msg + assistant msg."""
+        # Represents: [role_tokens] user_content [unmask_begin] assistant_content [unmask_end] [eos]
+        return [50, 51, 52, 1000, 200, 201, 202, 1001, 0]
+
+    def test_unmask_messages_basic_flow(self, mock_tokenizer):
+        """Test the basic flow of unmask_messages."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+
+        # Mock apply_chat_template to return our simple input sequence
+        mock_tokenizer.apply_chat_template.return_value = [50, 1000, 200, 201, 1001, 0]
+
+        result = unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+        # Verify the result structure
+        assert "input_ids" in result
+        assert "labels" in result
+        assert "len" in result
+        assert len(result["input_ids"]) == len(result["labels"])
+
+        # Should not contain unmask tokens in final output
+        assert 1000 not in result["input_ids"]  # UNMASK_BEGIN_TOKEN
+        assert 1001 not in result["input_ids"]  # UNMASK_END_TOKEN
+
+    def test_unmask_messages_assistant_only_unmasking(self, mock_tokenizer):
+        """Test that only assistant tokens are unmasked when specified."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+
+        # Sequence: user_tokens + unmask_begin + assistant_tokens + unmask_end
+        mock_tokenizer.apply_chat_template.return_value = [50, 51, 1000, 200, 201, 1001]
+
+        result = unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+        # User tokens should be masked (-100), assistant tokens should be unmasked
+        expected_input_ids = [50, 51, 200, 201]
+        expected_labels = [-100, -100, 200, 201]
+
+        assert result["input_ids"] == expected_input_ids
+        assert result["labels"] == expected_labels
+
+    def test_unmask_messages_multiple_roles(self, mock_tokenizer):
+        """Test unmasking multiple roles."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+
+        # Both user and assistant wrapped with unmask tokens
+        mock_tokenizer.apply_chat_template.return_value = [
+            1000,
+            50,
+            51,
+            1001,  # user wrapped
+            1000,
+            200,
+            201,
+            1001,  # assistant wrapped
+        ]
+
+        result = unmask_messages(messages, mock_tokenizer, ["user", "assistant"])
+
+        # Both should be unmasked
+        expected_input_ids = [50, 51, 200, 201]
+        expected_labels = [50, 51, 200, 201]
+
+        assert result["input_ids"] == expected_input_ids
+        assert result["labels"] == expected_labels
+
+    def test_unmask_messages_with_eos_token_for_assistant(self, mock_tokenizer):
+        """Test that EOS token is unmasked for assistant role."""
+        messages = [{"role": "assistant", "content": "Hello"}]
+
+        # Assistant content followed by EOS token
+        mock_tokenizer.apply_chat_template.return_value = [1000, 200, 201, 1001, 0]
+
+        result = unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+        # Both assistant content and EOS should be unmasked
+        expected_input_ids = [200, 201, 0]
+        expected_labels = [200, 201, 0]
+
+        assert result["input_ids"] == expected_input_ids
+        assert result["labels"] == expected_labels
+
+    def test_unmask_messages_no_eos_token(self, mock_tokenizer):
+        """Test behavior when tokenizer has no EOS token."""
+        mock_tokenizer.eos_token = None
+        messages = [{"role": "assistant", "content": "Hello"}]
+
+        mock_tokenizer.apply_chat_template.return_value = [1000, 200, 201, 1001]
+
+        result = unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+        # Should work normally without EOS handling
+        expected_input_ids = [200, 201]
+        expected_labels = [200, 201]
+
+        assert result["input_ids"] == expected_input_ids
+        assert result["labels"] == expected_labels
+
+    def test_unmask_messages_validation_errors(self, mock_tokenizer):
+        """Test that validation errors are properly raised."""
+        messages = [{"role": "assistant", "content": "Hello"}]
+
+        # Simulate a bug where unmask tokens remain in output by mocking a faulty sequence
+        mock_tokenizer.apply_chat_template.return_value = [
+            1000,
+            200,
+            1000,
+            1001,
+        ]  # nested begin token
+
+        with pytest.raises(ValueError, match="encountered.*while already unmasking"):
+            unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+    def test_unmask_messages_mismatched_end_token(self, mock_tokenizer):
+        """Test error when encountering end token while not unmasking."""
+        messages = [{"role": "user", "content": "Hello"}]
+
+        # End token without begin token
+        mock_tokenizer.apply_chat_template.return_value = [200, 1001]
+
+        with pytest.raises(ValueError, match="encountered.*while not unmasking"):
+            unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+    def test_unmask_messages_empty_input(self, mock_tokenizer):
+        """Test behavior with empty input."""
+        mock_tokenizer.apply_chat_template.return_value = []
+
+        result = unmask_messages([], mock_tokenizer, ["assistant"])
+
+        assert result["input_ids"] == []
+        assert result["labels"] == []
+        assert result["len"] == 0
+
+    def test_unmask_messages_reasoning_content_handling(self, mock_tokenizer):
+        """Test that reasoning content is properly handled."""
+        messages = [
+            {"role": "assistant", "content": "Answer", "reasoning_content": "Thinking"}
+        ]
+
+        # When messages have reasoning content, wrap_masked_messages uses reasoning-specific tokens
+        mock_tokenizer.apply_chat_template.return_value = [
+            1002,  # UNMASK_REASONING_BEGIN
+            200,  # reasoning content
+            1003,  # UNMASK_REASONING_END
+            1000,  # UNMASK_BEGIN
+            100,  # content
+            1001,  # UNMASK_END
+        ]
+
+        # The new implementation correctly handles reasoning content
+        result = unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+        # Both reasoning and content should be unmasked
+        assert result["input_ids"] == [200, 100]
+        assert result["labels"] == [200, 100]
+        assert result["len"] == 2
+
+
+class TestWithRealTokenizers:
+    """Test with actual tokenizer implementations to ensure realistic behavior."""
+
+    @pytest.fixture(scope="class")
+    def test_tokenizer(self):
+        """Get a small test tokenizer."""
+        try:
+            # Use a small model for testing
+            tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-gpt2")
+
+            # Add the special tokens
+            tokenizer.add_special_tokens(
+                {
+                    "additional_special_tokens": [
+                        UNMASK_BEGIN_TOKEN,
+                        UNMASK_END_TOKEN,
+                        UNMASK_REASONING_BEGIN_TOKEN,
+                        UNMASK_REASONING_END_TOKEN,
+                    ]
+                }
+            )
+
+            # Set a simple chat template for testing
+            tokenizer.chat_template = "{% for message in messages %}{{ message['role'] }}: {{ message['content'] }}{% if message.get('reasoning_content') %} [REASONING: {{ message['reasoning_content'] }}]{% endif %}\n{% endfor %}"
+
+            return tokenizer
+        except Exception as e:
+            pytest.skip(f"Could not load test tokenizer: {e}")
+
+    def test_real_tokenizer_basic_functionality(self, test_tokenizer):
+        """Test basic functionality with a real tokenizer."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+
+        result = unmask_messages(messages, test_tokenizer, ["assistant"])
+
+        # Basic sanity checks
+        assert len(result["input_ids"]) > 0
+        assert len(result["labels"]) == len(result["input_ids"])
+        assert result["len"] == len(result["input_ids"])
+
+        # Check that some tokens are masked (-100) and some are not
+        masked_count = sum(1 for label in result["labels"] if label == -100)
+        unmasked_count = len(result["labels"]) - masked_count
+
+        assert masked_count > 0, "Should have some masked tokens"
+        assert unmasked_count > 0, "Should have some unmasked tokens"
+
+    def test_real_tokenizer_with_reasoning(self, test_tokenizer):
+        """Test reasoning content with a real tokenizer."""
+        messages = [
+            {"role": "user", "content": "What is 2+2?"},
+            {
+                "role": "assistant",
+                "content": "The answer is 4.",
+                "reasoning_content": "I need to calculate 2+2.",
+            },
+        ]
+
+        result = unmask_messages(messages, test_tokenizer, ["assistant"])
+
+        # Should have processed both content and reasoning_content
+        assert len(result["input_ids"]) > 5  # Should be reasonably long
+        assert result["len"] == len(result["input_ids"])
+
+        # Should have both masked and unmasked tokens
+        masked_count = sum(1 for label in result["labels"] if label == -100)
+        unmasked_count = len(result["labels"]) - masked_count
+
+        assert masked_count > 0, "Should have some masked tokens (user message)"
+        assert unmasked_count > 0, (
+            "Should have some unmasked tokens (assistant content + reasoning)"
+        )
+
+    def test_real_tokenizer_edge_cases(self, test_tokenizer):
+        """Test edge cases with real tokenizer."""
+        # Empty assistant message
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": ""},
+        ]
+
+        result = unmask_messages(messages, test_tokenizer, ["assistant"])
+        assert len(result["input_ids"]) > 0
+
+        # Only reasoning content, no regular content
+        messages = [
+            {"role": "user", "content": "Think about this"},
+            {"role": "assistant", "reasoning_content": "Let me think..."},
+        ]
+
+        result = unmask_messages(messages, test_tokenizer, ["assistant"])
+        assert len(result["input_ids"]) > 0
+
+        # Should have some unmasked tokens from reasoning
+        unmasked_count = sum(1 for label in result["labels"] if label != -100)
+        assert unmasked_count > 0, "Should have unmasked reasoning content"
+
+
+class TestErrorConditions:
+    """Test various error conditions and edge cases."""
+
+    @pytest.fixture
+    def mock_tokenizer(self):
+        """Mock tokenizer for error testing."""
+        tokenizer = Mock()
+        tokenizer.encode.side_effect = lambda text, add_special_tokens=False: {
+            UNMASK_BEGIN_TOKEN: [1000],
+            UNMASK_END_TOKEN: [1001],
+        }.get(text, [100])
+        tokenizer.eos_token = None
+        return tokenizer
+
+    def test_length_mismatch_error(self, mock_tokenizer):
+        """Test that length mismatches raise appropriate errors."""
+        # This would be an internal error where our processing logic fails
+        messages = [{"role": "assistant", "content": "Hello"}]
+        mock_tokenizer.apply_chat_template.return_value = [1000, 200, 1001]
+
+        # Mock a scenario where we somehow create mismatched lengths
+        with patch("instructlab.training.data_process.unmask_messages") as mock_unmask:
+            mock_unmask.side_effect = RuntimeError(
+                "final_input_ids and final_labels are not the same length"
+            )
+
+            with pytest.raises(
+                RuntimeError,
+                match="final_input_ids and final_labels are not the same length",
+            ):
+                mock_unmask(messages, mock_tokenizer, ["assistant"])
+
+    def test_unfinished_unmasking_error(self, mock_tokenizer):
+        """Test error when unmasking is not properly finished."""
+        messages = [{"role": "assistant", "content": "Hello"}]
+
+        # Begin token without end token
+        mock_tokenizer.apply_chat_template.return_value = [1000, 200]
+
+        with pytest.raises(
+            RuntimeError, match="unmasking finished but not all messages were processed"
+        ):
+            unmask_messages(messages, mock_tokenizer, ["assistant"])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
With Qwen3, there's an edge case which can result in the unmask/mask logic breaking during data processing.


Root Cause: The error occurs specifically when using the Qwen/Qwen3-32B tokenizer, not with Qwen/Qwen2.5-32B-Instruct. The problematic sample contains multiple <think> tags in the assistant's
 response.

Issue Location: The error occurs in data_process.py:555 in the unmask_messages function, where it encounters an <|UNMASK_END|> token while not in an unmasking state.

Key Findings:
1. Model-specific issue: The sample processes fine with Qwen/Qwen2.5-32B-Instruct but fails with Qwen/Qwen3-32B
2. Chat template differences: Different models have different chat templates that may tokenize the unmask tokens differently
3. Token ordering: The issue suggests that the unmask tokens are getting reordered or processed incorrectly by the Qwen3 chat template

The Problem:
The Qwen/Qwen3-32B model's chat template is processing the <|UNMASK_BEGIN|> and <|UNMASK_END|> tokens in a way that causes them to appear out of order or in an unexpected state, leading to
the algorithm encountering an <|UNMASK_END|> token when it's not actively unmasking.

This is likely due to differences in how the chat templates of Qwen2.5 vs Qwen3 handle special tokens, particularly when there are multiple special tokens or complex content like the <think>
tags present in the assistant's response.


Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
