### PR TITLE
uncap accelerate in `requirements-cuda.txt`

### DIFF
--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -2,7 +2,7 @@ flash-attn>=2.4.0
 bitsandbytes>=0.43.1
 
 # required for FSDP updates
-accelerate>=0.34.2,<1.1.0
+accelerate>=0.34.2
 
 # first version that includes Granite kernels
 liger-kernel>=0.5.4


### PR DESCRIPTION
This reverts commit fdfb4fd2805298bb99aa77b427c3c519ab77643b.

This causes issues for downstream builders.

Fixes: #629 