### PR TITLE
ci: install git-core package instead of git

### DIFF
--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -29,7 +29,7 @@ runs:
       run: |
         cat /etc/os-release
         mkdir -p "${TMPDIR}"
-        sudo dnf install -y gcc gcc-c++ make git python${{ inputs.python-version }} python${{ inputs.python-version }}-devel
+        sudo dnf install -y gcc gcc-c++ make git-core python${{ inputs.python-version }} python${{ inputs.python-version }}-devel
 
     - name: Checkout instructlab/instructlab
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/e2e-nvidia-l40s-x4-sdk.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4-sdk.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           cat /etc/os-release
           mkdir -p "${TMPDIR}"
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git-core python3.11 python3.11-devel
   
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
`git` is a package that pulls in Perl, and we only need `git-core` for the basic Git client.