### PR TITLE
Add a tutorial for fine-tuning and interpolation

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,5 @@
+/nemotron.jsonl*
+/messages_data*.jsonl*
+/data*
+/experiments*
+/checkpoints*

--- a/examples/building_a_model_with_fine-tuning_and_interpolation.ipynb
+++ b/examples/building_a_model_with_fine-tuning_and_interpolation.ipynb
@@ -1,0 +1,363 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Building a model with fine-tuning and interpolation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Environment variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['PYTORCH_CUDA_ALLOC_CONF'] = \"expandable_segments:True\"\n",
+    "os.environ['TOKENIZERS_PARALLELISM'] = \"false\"\n",
+    "# os.environ['NCCL_DEBUG'] = \"INFO\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_path = \"ibm-granite/granite-3.3-8b-instruct\"\n",
+    "\n",
+    "model_name = os.path.basename(model_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure data\n",
+    "\n",
+    "Configure `data_name` such that the message data file is `message_data_${data_name}.jsonl`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_name = \"ibm-annual-report\"\n",
+    "\n",
+    "_data_name = f\"_{data_name}\" if data_name is not None and len(data_name) > 0 else \"\"\n",
+    "\n",
+    "messages_data_path = f\"messages_data{_data_name}.jsonl\"\n",
+    "\n",
+    "force_process_data = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure fine-tuning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_epochs = 3\n",
+    "save_samples = 0\n",
+    "keep_last_checkpoint_only = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure interpolation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trained_model_weight = 0.5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fine-tuning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "assert torch.cuda.is_available()\n",
+    "nproc_per_node = torch.cuda.device_count()\n",
+    "print(f\"nproc_per_node: {nproc_per_node}\", flush=True)\n",
+    "\n",
+    "nnodes = 1\n",
+    "print(f\"nnodes: {nnodes}\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat_tmpl_dir = \"../src/instructlab/training/chat_templates\"\n",
+    "if \"granite\" in model_name:\n",
+    "    chat_tmpl_path = f\"{chat_tmpl_dir}/ibm_generic_tmpl.py\"\n",
+    "else:\n",
+    "    chat_tmpl_path = None\n",
+    "\n",
+    "ckpt_output_dir = f\"experiments/training_output-{model_name}{_data_name}\"\n",
+    "processed_data_dir = f\"data/processed-data-{model_name}{_data_name}\"\n",
+    "\n",
+    "process_data = not os.path.isfile(f\"{processed_data_dir}/data.jsonl\") or force_process_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For fine-tuning, we use the Instructlab Training library, built for optimal and efficient fine-tuning on any messages-format data. Using the python interface, we are able to launch the model training.\n",
+    "\n",
+    "In this case, we ensure that we install off of main, to get the latest generic Causal LM support:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# %pip install git+https://github.com/instructlab/training.git@main"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We start by importing the necessary pieces from the library:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from instructlab.training.config import (\n",
+    "    TorchrunArgs,\n",
+    "    TrainingArgs,\n",
+    "    DistributedBackend,\n",
+    "    FSDPOptions,\n",
+    ")\n",
+    "from instructlab.training.main_ds import run_training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We then define our distributed settings via TorchrunArgs. In our case, we trained on a single node with 8 H100 GPUs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch_args = TorchrunArgs(\n",
+    "    nproc_per_node=nproc_per_node,\n",
+    "    nnodes=nnodes,\n",
+    "    node_rank=0,\n",
+    "    rdzv_id=123,\n",
+    "    rdzv_endpoint=\"0.0.0.0:8888\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We then set our model and data paths, checkpoint output path, and hyperparameters via the TrainingArgs object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_args = TrainingArgs(\n",
+    "    model_path=model_path,\n",
+    "    chat_tmpl_path=chat_tmpl_path,\n",
+    "    data_path=messages_data_path,\n",
+    "    ckpt_output_dir=ckpt_output_dir,\n",
+    "    data_output_dir=processed_data_dir,  # processed data ids/labels/masks\n",
+    "    max_seq_len=20000,\n",
+    "    max_batch_len=30000,  # max tokens per gpu\n",
+    "    num_epochs=num_epochs,\n",
+    "    effective_batch_size=256,  # target batch size per model update\n",
+    "    learning_rate=2e-5,\n",
+    "    warmup_steps=25,\n",
+    "    save_samples=save_samples,  # save ckpt after num of samples seen (0=off)\n",
+    "    checkpoint_at_epoch=True,  # save ckpt after every epoch\n",
+    "    accelerate_full_state_at_epoch=False,  # save full-state for resuming\n",
+    "    process_data=process_data,  # can set to false if data processed before\n",
+    "    keep_last_checkpoint_only=keep_last_checkpoint_only,\n",
+    "    distributed_backend=DistributedBackend.FSDP,\n",
+    "    fsdp_options=FSDPOptions(cpu_offload_params=False),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we kick off SFT via the run_training function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Start training\", flush=True)\n",
+    "\n",
+    "run_training(torch_args=torch_args,train_args=train_args)\n",
+    "\n",
+    "print(\"Finished training\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Upon completion, we have `{num_epochs}` Huggingface-Format checkpoints in `{ckpt_output_dir}/hf_format`. The full run logs and metrics will also be recorded in `{ckpt_output_dir}`. Running the final training as a python script rather than in a notebook may help with progress bar writing to stdout."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interpolation\n",
+    "\n",
+    "When the training is completed successfully, we will interpolate the last checkpoint with the original model to recover the capability that may have been lost during the training process. `{output_model_path}` will be `{trained_model_path}-interp` by default.\n",
+    "\n",
+    "We can also interpolate models manually as follows.\n",
+    "```sh\n",
+    "python interpolator.py --model_path {model_path} --trained_model_path {trained_model_path} --trained_model_weight {trained_model_weight}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "\n",
+    "def find_last_checkpoint(ckpt_output_dir: str) -> str | None:\n",
+    "    last_checkpoint_path = None\n",
+    "\n",
+    "    # For keep_last_checkpoint_only is True\n",
+    "    # See https://github.com/instructlab/training/blob/4eb4173f2508dc1fd8db7e30b59609f0ceeb25ac/src/instructlab/training/config.py#L229\n",
+    "    ckpt_dirs = glob.glob(f\"{ckpt_output_dir}/hf_format/last_epoch\")\n",
+    "    for ckpt_dir in ckpt_dirs:\n",
+    "        last_checkpoint_path = ckpt_dir\n",
+    "\n",
+    "    # For keep_last_checkpoint_only is False\n",
+    "    if last_checkpoint_path is None:\n",
+    "        ckpt_dirs = glob.glob(f\"{ckpt_output_dir}/hf_format/samples_*\")\n",
+    "        samples_len = len(\"samples_\")\n",
+    "        max_num_samples = -1\n",
+    "        for ckpt_dir in ckpt_dirs:\n",
+    "            if not os.path.isdir(ckpt_dir):\n",
+    "                continue\n",
+    "            num_samples_str = os.path.basename(ckpt_dir)[samples_len:]\n",
+    "            try:\n",
+    "                num_samples = int(num_samples_str)\n",
+    "            except ValueError:\n",
+    "                continue\n",
+    "            if max_num_samples < num_samples:\n",
+    "                max_num_samples = num_samples\n",
+    "                last_checkpoint_path = ckpt_dir\n",
+    "\n",
+    "    return last_checkpoint_path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trained_model_path = find_last_checkpoint(ckpt_output_dir)\n",
+    "\n",
+    "if trained_model_path is not None:\n",
+    "    from interpolator import interpolate_models\n",
+    "\n",
+    "    print(f\"Trained model path: {trained_model_path}\")\n",
+    "\n",
+    "    output_model_path = interpolate_models(model_path, trained_model_path, trained_model_weight=trained_model_weight)\n",
+    "\n",
+    "    print(f\"Output model path: {output_model_path}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "training-py311",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/building_a_model_with_fine-tuning_and_interpolation.ipynb
+++ b/examples/building_a_model_with_fine-tuning_and_interpolation.ipynb
@@ -141,7 +141,9 @@
     "ckpt_output_dir = f\"experiments/training_output-{model_name}{_data_name}\"\n",
     "processed_data_dir = f\"data/processed-data-{model_name}{_data_name}\"\n",
     "\n",
-    "process_data = not os.path.isfile(f\"{processed_data_dir}/data.jsonl\") or force_process_data"
+    "process_data = (\n",
+    "    not os.path.isfile(f\"{processed_data_dir}/data.jsonl\") or force_process_data\n",
+    ")"
    ]
   },
   {
@@ -257,7 +259,7 @@
    "source": [
     "print(\"Start training\", flush=True)\n",
     "\n",
-    "run_training(torch_args=torch_args,train_args=train_args)\n",
+    "run_training(torch_args=torch_args, train_args=train_args)\n",
     "\n",
     "print(\"Finished training\", flush=True)"
    ]
@@ -290,6 +292,7 @@
    "outputs": [],
    "source": [
     "import glob\n",
+    "\n",
     "\n",
     "def find_last_checkpoint(ckpt_output_dir: str) -> str | None:\n",
     "    last_checkpoint_path = None\n",
@@ -333,7 +336,9 @@
     "\n",
     "    print(f\"Trained model path: {trained_model_path}\")\n",
     "\n",
-    "    output_model_path = interpolate_models(model_path, trained_model_path, trained_model_weight=trained_model_weight)\n",
+    "    output_model_path = interpolate_models(\n",
+    "        model_path, trained_model_path, trained_model_weight=trained_model_weight\n",
+    "    )\n",
     "\n",
     "    print(f\"Output model path: {output_model_path}\")"
    ]

--- a/examples/building_a_model_with_fine-tuning_and_interpolation.ipynb
+++ b/examples/building_a_model_with_fine-tuning_and_interpolation.ipynb
@@ -22,9 +22,9 @@
    "source": [
     "import os\n",
     "\n",
-    "os.environ['PYTORCH_CUDA_ALLOC_CONF'] = \"expandable_segments:True\"\n",
-    "os.environ['TOKENIZERS_PARALLELISM'] = \"false\"\n",
-    "# os.environ['NCCL_DEBUG'] = \"INFO\""
+    "os.environ[\"PYTORCH_CUDA_ALLOC_CONF\"] = \"expandable_segments:True\"\n",
+    "os.environ[\"TOKENIZERS_PARALLELISM\"] = \"false\"\n",
+    "# os.environ[\"NCCL_DEBUG\"] = \"INFO\""
    ]
   },
   {

--- a/examples/interpolator.py
+++ b/examples/interpolator.py
@@ -1,4 +1,7 @@
+# Standard
 import argparse
+
+# Third Party
 from transformers import AutoTokenizer, AutoModelForCausalLM
 
 

--- a/examples/interpolator.py
+++ b/examples/interpolator.py
@@ -1,0 +1,104 @@
+import argparse
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+
+def interpolate_models(
+    model_path: str,
+    trained_model_path: str,
+    trained_model_weight: float = 0.5,
+    output_model_path: str | None = None,
+    torch_dtype: str | None = "bfloat16",
+) -> str:
+    if output_model_path is None:
+        output_model_path = f"{trained_model_path}-interp"
+
+    model_kwargs: dict[str, any] = {}
+    if torch_dtype is not None and torch_dtype != "auto":
+        model_kwargs["torch_dtype"] = torch_dtype
+
+    # load original model
+    model = AutoModelForCausalLM.from_pretrained(
+        model_path,
+        **model_kwargs,
+    )
+    state_dict = model.state_dict()
+    original_model_weight = 1 - trained_model_weight
+    for key in state_dict.keys():
+        state_dict[key] = state_dict[key] * original_model_weight
+
+    # load trained model
+    trained_model = AutoModelForCausalLM.from_pretrained(
+        trained_model_path,
+        **model_kwargs,
+    )
+    trained_state_dict = trained_model.state_dict()
+    for key in state_dict.keys():
+        state_dict[key] += trained_state_dict[key] * trained_model_weight
+
+    # save interpolated model
+    model.save_pretrained(output_model_path, state_dict=state_dict)
+
+    # copy tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    tokenizer.save_pretrained(output_model_path)
+
+    return output_model_path
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        required=True,
+        help="path to the original model",
+    )
+    parser.add_argument(
+        "--trained_model_path",
+        type=str,
+        required=True,
+        help="path to the trained model",
+    )
+    parser.add_argument(
+        "--trained_model_weight",
+        type=float,
+        default=0.5,
+        help="weight for the trained model",
+    )
+    parser.add_argument(
+        "--output_model_path",
+        type=str,
+        default=None,
+        help="path to the output model",
+    )
+    parser.add_argument(
+        "--torch_dtype",
+        type=str,
+        default="bfloat16",
+        help="torch dtype",
+    )
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_arguments()
+    model_path: str = args.model_path
+    trained_model_path: str = args.trained_model_path
+    trained_model_weight: float = args.trained_model_weight
+    output_model_path: str | None = args.output_model_path
+    torch_dtype: str | None = args.torch_dtype
+
+    interpolate_models(
+        model_path,
+        trained_model_path,
+        trained_model_weight=trained_model_weight,
+        output_model_path=output_model_path,
+        torch_dtype=torch_dtype,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/interpolator.py
+++ b/examples/interpolator.py
@@ -2,7 +2,7 @@
 import argparse
 
 # Third Party
-from transformers import AutoTokenizer, AutoModelForCausalLM
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
 def interpolate_models(


### PR DESCRIPTION
This tutorial aims to guide you through building a model with fine-tuning followed by interpolation.
Based on [the tutorial for building a reasoning model](examples/01_building_a_reasoning_model.ipynb), [this tutorial](examples/building_a_model_with_fine-tuning_and_interpolation.ipynb) has the minimum changes described below.
- Use granite-3.3-8b-instruct as the student model.
- Apply the pre-defined chat template for granite models.
- After fine-tuning, interpolate the last checkpoint with the original student model.