### PR TITLE
Update numpy from <2.0 to <2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ transformers>=4.55.0
 
 datasets>=2.15.0
 numba
-numpy>=1.26.4,<2.0.0
+numpy>=1.26.4,<2.3
 rich
 trl>=0.9.4
 peft


### PR DESCRIPTION
Bumping `numpy` cap since Numba now supports Numpy <2.3