### PR TITLE
Update requirements-cuda.txt to increase liger-kernel minimum

### DIFF
--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -5,5 +5,5 @@ kernels>=0.9.0
 # required for FSDP updates
 accelerate>=0.34.2
 
-# first version that includes Granite kernels
-liger-kernel>=0.5.4
+# earliest fully-compatible version with updated architecture support
+liger-kernel>=0.5.10


### PR DESCRIPTION
Found that liger-kernel<0.5.10 was causing some incompatibility issues with more recent models