### PR TITLE
fix(torchrun): Omit empty arguments and correct nproc_per_node type

### DIFF
--- a/src/instructlab/training/config.py
+++ b/src/instructlab/training/config.py
@@ -75,7 +75,7 @@ class TorchrunArgs(BaseModel):
     https://pytorch.org/docs/stable/elastic/run.html#definitions
     """
 
-    nproc_per_node: int
+    nproc_per_node: str
     nnodes: int
     node_rank: int
     rdzv_id: int

--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -480,26 +480,24 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
     if not os.path.exists(train_args.ckpt_output_dir):
         os.makedirs(train_args.ckpt_output_dir, exist_ok=True)
 
-    command = [
-        "torchrun",
-        f"--nnodes={torch_args.nnodes}",
-        f"--node_rank={torch_args.node_rank}",
-        f"--nproc_per_node={torch_args.nproc_per_node}",
-        f"--rdzv_id={torch_args.rdzv_id}",
-        f"--rdzv_endpoint={torch_args.rdzv_endpoint}",
-        __file__,
-        f"--model_name_or_path={train_args.model_path}",
-        f"--data_path={train_args.data_output_dir}/data.jsonl",
-        f"--output_dir={train_args.ckpt_output_dir}",
-        f"--num_epochs={train_args.num_epochs}",
-        f"--effective_batch_size={train_args.effective_batch_size}",
-        f"--learning_rate={train_args.learning_rate}",
-        f"--num_warmup_steps={train_args.warmup_steps}",
-        f"--save_samples={train_args.save_samples}",
-        f"--log_level={train_args.log_level}",
-        f"--max_batch_len={train_args.max_batch_len}",
-        f"--seed={train_args.random_seed}",
-    ]
+    # building torchrun command
+    command = ["torchrun"]
+
+    # ignore empty or unset values from the command
+    for key, value in torch_args.model_dump(exclude_none=True).items():
+        if not isinstance(value, int) and (not value or value == ""):
+            continue
+        command.append(f"--{key}={value}")
+
+    # append this file as main script to run by torchrun
+    command.append(__file__)
+
+    # build args for this file. Ignore empty or unset values except int values
+    for key, value in train_args.model_dump(exclude_none=True).items():
+        # avoid ignoring int attrs with value = 0
+        if not isinstance(value, int) and (not value or value == ""):
+            continue
+        command.append(f"--{key}={value}")
 
     if train_args.chat_tmpl_path is not None:
         command.append(f"--chat-tmpl-path={train_args.chat_tmpl_path}")


### PR DESCRIPTION
The command generation logic is updated to dynamically build the torchrun command, excluding arguments that are empty or None. This prevents them from overriding environment variables, ensuring that torchrun can
correctly inherit its configuration. An exception is made for integer arguments where 0 is a valid value.

Additionally, the nproc_per_node argument type has been changed from int to str to support special values
accepted by PyTorch, such as 'auto', 'gpu', and 'cpu'.

Reference: https://github.com/pytorch/pytorch/blob/main/torch/distributed/run.py#L77-L88