### PR TITLE
Adds mamba-ssm[causal-conv1d] to CUDA requirements

### DIFF
--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -7,3 +7,7 @@ accelerate>=0.34.2
 
 # earliest fully-compatible version with updated architecture support
 liger-kernel>=0.5.10
+
+# add mamba requirements
+mamba-ssm[causal-conv1d]>=2.2.5
+

--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -1,3 +1,7 @@
 flash-attn>=2.6.2
 # required for FSDP updates
 accelerate>=0.34.2
+
+# In order to run Mamba architectures
+mamba-ssm[causal-conv1d]>=2.2.5
+


### PR DESCRIPTION
This PR adds the following packages to be installed as part of `instructlab-training[cuda]`:

```
uv pip install --dry-run mamba-ssm[causal-conv1d] --no-build-isolation
Resolved 44 packages in 16ms
Would download 2 packages
Would install 2 packages
 + causal-conv1d==1.5.2
 + mamba-ssm==2.2.5
```

