### PR TITLE
fixes stray invalid variable access bug

### DIFF
--- a/src/instructlab/training/data_process.py
+++ b/src/instructlab/training/data_process.py
@@ -1257,7 +1257,7 @@ def analyze_dataset_statistics(
 
     if num_dropped_samples == len(data):
         raise RuntimeError(
-            f"Dataset does not contain any samples containing less than {args.max_seq_len=} tokens.\n"
+            f"Dataset does not contain any samples containing less than {max_seq_len=} tokens.\n"
             f"Please consider increasing your `max_seq_len` value, or adding more samples."
         )
 


### PR DESCRIPTION
The `analyze_dataset_statistics` function is using `args.max_seq_len` when reporting an error instead of the `max_seq_len` arg that it was given. This causes API-based data processing to break since the global `args` is only defined when we parse out the CLI arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Clarified an internal error message relating to dataset token-length validation so it references the correct local parameter, improving clarity when encountering dataset size/sequence issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->