### PR TITLE
bumps hynek build dep

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -43,7 +43,7 @@ jobs:
                   fetch-depth: 0
 
             - name: "Build and Inspect"
-              uses: hynek/build-and-inspect-python-package@c52c3a4710070b50470d903818a7b25115dcd076 # v2.13.0
+              uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
 
     # push to Test PyPI on
     # - a new GitHub release is published


### PR DESCRIPTION
this fixes an issue in CI where it cannot build packages due to a python incompatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to use a newer action version for improved reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->