### PR TITLE
fixes bug where process isn't completed by the time the process gets read

### DIFF
--- a/src/instructlab/training/main_ds.py
+++ b/src/instructlab/training/main_ds.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 import os
 import subprocess
+import sys
 import time
 import warnings
 
@@ -645,11 +646,17 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
         if "process" not in locals() or process is None:
             return
 
-        failure = process.poll() != 0
+        # wait for the process to exit so we can properly read the exit code
+        process.wait(timeout=60)
+        process_code = process.poll()
+        failure = process_code != 0
+
         if not failure:
             logger.info("Operation completed successfully! 🎉")
         else:
-            logger.error("Training subprocess has not exited yet. Sending SIGTERM.")
+            logger.error(
+                f"Training subprocess has not exited yet. Sending SIGTERM. Process code: {process_code}"
+            )
 
         process.terminate()
         try:


### PR DESCRIPTION
This PR solves a race condition in the current codebase where `process.poll()` is called
before the child process has fully completed which causes the check of `process.poll() != 0`
to return True.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved training subprocess exit handling with enhanced error reporting that includes process exit status
  * Strengthened cleanup logic with graceful process termination followed by forced termination on timeout

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->