### PR TITLE
Pin transformers version to <5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ wheel>=0.43
 pyyaml
 py-cpuinfo
 torch>=2.6.0
-transformers>=4.55.0
+transformers>=4.55.0,<5
 
 datasets>=2.15.0
 numba>=0.62.0


### PR DESCRIPTION
## Summary
- Constrains the transformers dependency to versions `>=4.55.0,<5`
- Prevents potential breaking changes from major version updates

## Test plan
- [ ] Verify the package installs correctly with the new constraint
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated transformers library dependency constraint to ensure compatibility with stable versions while preventing issues from future major releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->