### PR TITLE
fix _no_split_modules subscript error for transformers v5

### DIFF
--- a/src/instructlab/training/accelerator.py
+++ b/src/instructlab/training/accelerator.py
@@ -135,7 +135,7 @@ class Accelerator:
 
     def get_fsdp_config(self):
         is_lora = self.model.lora_config is not None
-        block_name = self.model._no_split_modules[0]
+        block_name = next(iter(self.model._no_split_modules))
 
         wrap_policy = None
         if is_lora > 0:

--- a/tests/unit/test_accelerator.py
+++ b/tests/unit/test_accelerator.py
@@ -18,7 +18,7 @@ def mock_model():
     model = MagicMock(spec=Model)
     model.model = MagicMock()
     model.lora_config = None
-    model._no_split_modules = ["LlamaDecoderLayer"]
+    model._no_split_modules = {"LlamaDecoderLayer"}
     # Add children method to model
     model.children = MagicMock(return_value=[])
     model.model.children = MagicMock(return_value=[])


### PR DESCRIPTION
## Summary

Fixes `TypeError: 'set' object is not subscriptable` when running FSDP training with transformers v5.x.

In transformers v5, `_no_split_modules` is now converted to a `set` during model initialization (`post_init()`), whereas it was previously a `list`. The code in `get_fsdp_config()` was using `[0]` to access the first element, which fails on sets.

**Fix:** Use `next(iter(...))` to retrieve an element, which works with both sets and lists.

## Test plan

- [x] Verified fix resolves the error in SFT validation script
- [x] Updated unit test mock to use a set to match transformers v5 behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of the FSDP wrap policy configuration during model acceleration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->