### PR TITLE
Relax numba pin from >=0.62.0 to >=0.61.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ torch>=2.6.0
 transformers>=4.57.1
 
 datasets>=2.15.0
-numba>=0.62.0
+numba>=0.61.2
 numpy>=1.26.4
 rich
 trl>=0.9.4


### PR DESCRIPTION
## Summary
Relaxes the numba version pin from `>=0.62.0` to `>=0.61.2` to resolve a dependency conflict with vllm, which pins `numba==0.61.2`.

The numba usage in this project (basic `@njit` decorators and `int64` types) is fully compatible with numba 0.61.x — no 0.62-specific APIs are used.

## Motivation
When installing alongside `vllm<=0.15.1` (used by verl for GRPO training), pip/uv cannot satisfy both `numba>=0.62.0` and vllm's `numba==0.61.2` pin, causing dependency resolution failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced minimum Numba version requirement to improve compatibility with existing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->